### PR TITLE
Reduce RealityKit GPU read/write bandwidth on blit/raster, fix edge shimmering by generating mipmaps, avoid intermediate pixel formats, improve NAL throughput

### DIFF
--- a/Moonlight Vision/CVMetalHelpers.swift
+++ b/Moonlight Vision/CVMetalHelpers.swift
@@ -1,0 +1,366 @@
+//
+//  CVMetalHelpers.swift
+//
+//  Created by Max Thomas
+//  No license, do whatever you want with this file
+//
+
+
+#if !targetEnvironment(simulator)
+let forceFastSecretTextureFormats = true
+#else
+let forceFastSecretTextureFormats = false
+#endif
+
+//
+// Non-conclusive list of interesting private Metal pixel formats
+// https://gist.github.com/shinyquagsire23/81c86f4bf670aaa68b5804080ff964a0
+//
+let MTLPixelFormatYCBCR8_420_2P: UInt = 500
+let MTLPixelFormatYCBCR8_422_1P: UInt = 501
+let MTLPixelFormatYCBCR8_422_2P: UInt = 502
+let MTLPixelFormatYCBCR8_444_2P: UInt = 503
+let MTLPixelFormatYCBCR10_444_1P: UInt = 504
+let MTLPixelFormatYCBCR10_420_2P: UInt = 505
+let MTLPixelFormatYCBCR10_422_2P: UInt = 506
+let MTLPixelFormatYCBCR10_444_2P: UInt = 507
+let MTLPixelFormatYCBCR10_420_2P_PACKED: UInt = 508
+let MTLPixelFormatYCBCR10_422_2P_PACKED: UInt = 509
+let MTLPixelFormatYCBCR10_444_2P_PACKED: UInt = 510
+
+let MTLPixelFormatYCBCR8_420_2P_sRGB: UInt = 520
+let MTLPixelFormatYCBCR8_422_1P_sRGB: UInt = 521
+let MTLPixelFormatYCBCR8_422_2P_sRGB: UInt = 522
+let MTLPixelFormatYCBCR8_444_2P_sRGB: UInt = 523
+let MTLPixelFormatYCBCR10_444_1P_sRGB: UInt = 524
+let MTLPixelFormatYCBCR10_420_2P_sRGB: UInt = 525
+let MTLPixelFormatYCBCR10_422_2P_sRGB: UInt = 526
+let MTLPixelFormatYCBCR10_444_2P_sRGB: UInt = 527
+let MTLPixelFormatYCBCR10_420_2P_PACKED_sRGB: UInt = 528
+let MTLPixelFormatYCBCR10_422_2P_PACKED_sRGB: UInt = 529
+let MTLPixelFormatYCBCR10_444_2P_PACKED_sRGB: UInt = 530
+
+let MTLPixelFormatRGB8_420_2P: UInt = 540
+let MTLPixelFormatRGB8_422_2P: UInt = 541
+let MTLPixelFormatRGB8_444_2P: UInt = 542
+let MTLPixelFormatRGB10_420_2P: UInt = 543
+let MTLPixelFormatRGB10_422_2P: UInt = 544
+let MTLPixelFormatRGB10_444_2P: UInt = 545
+let MTLPixelFormatRGB10_420_2P_PACKED: UInt = 546
+let MTLPixelFormatRGB10_422_2P_PACKED: UInt = 547
+let MTLPixelFormatRGB10_444_2P_PACKED: UInt = 548
+
+let MTLPixelFormatRGB10A8_2P_XR10: UInt = 550
+let MTLPixelFormatRGB10A8_2P_XR10_sRGB: UInt = 551
+let MTLPixelFormatBGRA10_XR: UInt = 552
+let MTLPixelFormatBGRA10_XR_sRGB: UInt = 553
+let MTLPixelFormatBGR10_XR: UInt = 554
+let MTLPixelFormatBGR10_XR_sRGB: UInt = 555
+let MTLPixelFormatRGBA16Float_XR: UInt = 556
+
+let MTLPixelFormatYCBCRA8_444_1P: UInt = 560
+
+let MTLPixelFormatYCBCR12_420_2P: UInt = 570
+let MTLPixelFormatYCBCR12_422_2P: UInt = 571
+let MTLPixelFormatYCBCR12_444_2P: UInt = 572
+let MTLPixelFormatYCBCR12_420_2P_PQ: UInt = 573
+let MTLPixelFormatYCBCR12_422_2P_PQ: UInt = 574
+let MTLPixelFormatYCBCR12_444_2P_PQ: UInt = 575
+let MTLPixelFormatR10Unorm_X6: UInt = 576
+let MTLPixelFormatR10Unorm_X6_sRGB: UInt = 577
+let MTLPixelFormatRG10Unorm_X12: UInt = 578
+let MTLPixelFormatRG10Unorm_X12_sRGB: UInt = 579
+let MTLPixelFormatYCBCR12_420_2P_PACKED: UInt = 580
+let MTLPixelFormatYCBCR12_422_2P_PACKED: UInt = 581
+let MTLPixelFormatYCBCR12_444_2P_PACKED: UInt = 582
+let MTLPixelFormatYCBCR12_420_2P_PACKED_PQ: UInt = 583
+let MTLPixelFormatYCBCR12_422_2P_PACKED_PQ: UInt = 584
+let MTLPixelFormatYCBCR12_444_2P_PACKED_PQ: UInt = 585
+let MTLPixelFormatRGB10A2Unorm_sRGB: UInt = 586
+let MTLPixelFormatRGB10A2Unorm_PQ: UInt = 587
+let MTLPixelFormatR10Unorm_PACKED: UInt = 588
+let MTLPixelFormatRG10Unorm_PACKED: UInt = 589
+let MTLPixelFormatYCBCR10_444_1P_XR: UInt = 590
+let MTLPixelFormatYCBCR10_420_2P_XR: UInt = 591
+let MTLPixelFormatYCBCR10_422_2P_XR: UInt = 592
+let MTLPixelFormatYCBCR10_444_2P_XR: UInt = 593
+let MTLPixelFormatYCBCR10_420_2P_PACKED_XR: UInt = 594
+let MTLPixelFormatYCBCR10_422_2P_PACKED_XR: UInt = 595
+let MTLPixelFormatYCBCR10_444_2P_PACKED_XR: UInt = 596
+let MTLPixelFormatYCBCR12_420_2P_XR: UInt = 597
+let MTLPixelFormatYCBCR12_422_2P_XR: UInt = 598
+let MTLPixelFormatYCBCR12_444_2P_XR: UInt = 599
+let MTLPixelFormatYCBCR12_420_2P_PACKED_XR: UInt = 600
+let MTLPixelFormatYCBCR12_422_2P_PACKED_XR: UInt = 601
+let MTLPixelFormatYCBCR12_444_2P_PACKED_XR: UInt = 602
+let MTLPixelFormatR12Unorm_X4: UInt = 603
+let MTLPixelFormatR12Unorm_X4_PQ: UInt = 604
+let MTLPixelFormatRG12Unorm_X8: UInt = 605
+let MTLPixelFormatR10Unorm_X6_PQ: UInt = 606
+//
+// end Metal pixel formats
+//
+
+// https://github.com/WebKit/WebKit/blob/f86d3400c875519b3f3c368f1ea9a37ed8a1d11b/Source/WebGPU/WebGPU/BindGroup.mm#L43
+let kCVPixelFormatType_420YpCbCr10PackedBiPlanarFullRange = 0x70663230 as OSType // pf20
+let kCVPixelFormatType_422YpCbCr10PackedBiPlanarFullRange = 0x70663232 as OSType // pf22
+let kCVPixelFormatType_444YpCbCr10PackedBiPlanarFullRange = 0x70663434 as OSType // pf44
+
+let kCVPixelFormatType_420YpCbCr10PackedBiPlanarVideoRange = 0x70343230 as OSType // p420
+let kCVPixelFormatType_422YpCbCr10PackedBiPlanarVideoRange = 0x70343232 as OSType // p422
+let kCVPixelFormatType_444YpCbCr10PackedBiPlanarVideoRange = 0x70343434 as OSType // p444
+
+// Apparently kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange is known as kCVPixelFormatType_AGX_420YpCbCr8BiPlanarVideoRange in WebKit.
+
+// Other formats Apple forgot
+let kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarFullRange = 0x2D786630 as OSType // -xf0
+let kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarFullRange = 0x26786632 as OSType // &xf2
+let kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarFullRange = 0x2D786632 as OSType // -xf2
+let kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarFullRange_compat = 0x26786630 as OSType // &xf0
+
+class CVMetalHelpers {
+    // Useful for debugging.
+    static let coreVideoPixelFormatToStr: [OSType:String] = [
+        kCVPixelFormatType_128RGBAFloat: "128RGBAFloat",
+        kCVPixelFormatType_14Bayer_BGGR: "BGGR",
+        kCVPixelFormatType_14Bayer_GBRG: "GBRG",
+        kCVPixelFormatType_14Bayer_GRBG: "GRBG",
+        kCVPixelFormatType_14Bayer_RGGB: "RGGB",
+        kCVPixelFormatType_16BE555: "16BE555",
+        kCVPixelFormatType_16BE565: "16BE565",
+        kCVPixelFormatType_16Gray: "16Gray",
+        kCVPixelFormatType_16LE5551: "16LE5551",
+        kCVPixelFormatType_16LE555: "16LE555",
+        kCVPixelFormatType_16LE565: "16LE565",
+        kCVPixelFormatType_16VersatileBayer: "16VersatileBayer",
+        kCVPixelFormatType_1IndexedGray_WhiteIsZero: "WhiteIsZero",
+        kCVPixelFormatType_1Monochrome: "1Monochrome",
+        kCVPixelFormatType_24BGR: "24BGR",
+        kCVPixelFormatType_24RGB: "24RGB",
+        kCVPixelFormatType_2Indexed: "2Indexed",
+        kCVPixelFormatType_2IndexedGray_WhiteIsZero: "WhiteIsZero",
+        kCVPixelFormatType_30RGB: "30RGB",
+        kCVPixelFormatType_30RGBLEPackedWideGamut: "30RGBLEPackedWideGamut",
+        kCVPixelFormatType_32ABGR: "32ABGR",
+        kCVPixelFormatType_32ARGB: "32ARGB",
+        kCVPixelFormatType_32AlphaGray: "32AlphaGray",
+        kCVPixelFormatType_32BGRA: "32BGRA",
+        kCVPixelFormatType_32RGBA: "32RGBA",
+        kCVPixelFormatType_40ARGBLEWideGamut: "40ARGBLEWideGamut",
+        kCVPixelFormatType_40ARGBLEWideGamutPremultiplied: "40ARGBLEWideGamutPremultiplied",
+        kCVPixelFormatType_420YpCbCr10BiPlanarFullRange: "420YpCbCr10BiPlanarFullRange",
+        kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange: "420YpCbCr10BiPlanarVideoRange",
+        kCVPixelFormatType_420YpCbCr8BiPlanarFullRange: "420YpCbCr8BiPlanarFullRange",
+        kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange: "420YpCbCr8BiPlanarVideoRange",
+        kCVPixelFormatType_420YpCbCr8Planar: "420YpCbCr8Planar",
+        kCVPixelFormatType_420YpCbCr8PlanarFullRange: "420YpCbCr8PlanarFullRange",
+        kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar: "TriPlanar",
+        kCVPixelFormatType_422YpCbCr10: "422YpCbCr10",
+        kCVPixelFormatType_422YpCbCr10BiPlanarFullRange: "422YpCbCr10BiPlanarFullRange",
+        kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange: "422YpCbCr10BiPlanarVideoRange",
+        kCVPixelFormatType_422YpCbCr16: "422YpCbCr16",
+        kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange: "422YpCbCr16BiPlanarVideoRange",
+        kCVPixelFormatType_422YpCbCr8: "422YpCbCr8",
+        kCVPixelFormatType_422YpCbCr8BiPlanarFullRange: "422YpCbCr8BiPlanarFullRange",
+        kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange: "422YpCbCr8BiPlanarVideoRange",
+        kCVPixelFormatType_422YpCbCr8FullRange: "422YpCbCr8FullRange",
+        kCVPixelFormatType_422YpCbCr8_yuvs: "yuvs",
+        kCVPixelFormatType_422YpCbCr_4A_8BiPlanar: "8BiPlanar",
+        kCVPixelFormatType_4444AYpCbCr16: "4444AYpCbCr16",
+        kCVPixelFormatType_4444AYpCbCr8: "4444AYpCbCr8",
+        kCVPixelFormatType_4444YpCbCrA8: "4444YpCbCrA8",
+        kCVPixelFormatType_4444YpCbCrA8R: "4444YpCbCrA8R",
+        kCVPixelFormatType_444YpCbCr10: "444YpCbCr10",
+        kCVPixelFormatType_444YpCbCr10BiPlanarFullRange: "444YpCbCr10BiPlanarFullRange",
+        kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange: "444YpCbCr10BiPlanarVideoRange",
+        kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange: "444YpCbCr16BiPlanarVideoRange",
+        kCVPixelFormatType_444YpCbCr16VideoRange_16A_TriPlanar: "TriPlanar",
+        kCVPixelFormatType_444YpCbCr8: "444YpCbCr8",
+        kCVPixelFormatType_444YpCbCr8BiPlanarFullRange: "444YpCbCr8BiPlanarFullRange",
+        kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange: "444YpCbCr8BiPlanarVideoRange",
+        kCVPixelFormatType_48RGB: "48RGB",
+        kCVPixelFormatType_4Indexed: "4Indexed",
+        kCVPixelFormatType_4IndexedGray_WhiteIsZero: "WhiteIsZero",
+        kCVPixelFormatType_64ARGB: "64ARGB",
+        kCVPixelFormatType_64RGBAHalf: "64RGBAHalf",
+        kCVPixelFormatType_64RGBALE: "64RGBALE",
+        kCVPixelFormatType_64RGBA_DownscaledProResRAW: "DownscaledProResRAW",
+        kCVPixelFormatType_8Indexed: "8Indexed",
+        kCVPixelFormatType_8IndexedGray_WhiteIsZero: "WhiteIsZero",
+        kCVPixelFormatType_ARGB2101010LEPacked: "ARGB2101010LEPacked",
+        kCVPixelFormatType_DepthFloat16: "DepthFloat16",
+        kCVPixelFormatType_DepthFloat32: "DepthFloat32",
+        kCVPixelFormatType_DisparityFloat16: "DisparityFloat16",
+        kCVPixelFormatType_DisparityFloat32: "DisparityFloat32",
+        kCVPixelFormatType_Lossless_32BGRA: "32BGRA",
+        kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarFullRange_compat: "Lossless_420YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange: "Lossless_420YpCbCr10PackedBiPlanarVideoRange",
+        kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange: "Lossless_420YpCbCr8BiPlanarFullRange",
+        kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange: "Lossless_420YpCbCr8BiPlanarVideoRange",
+        kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarVideoRange: "Lossless_422YpCbCr10PackedBiPlanarVideoRange",
+        kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarFullRange: "Lossless_422YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_Lossy_32BGRA: "32BGRA",
+        kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarFullRange: "Lossy_420YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange: "Lossy_420YpCbCr10PackedBiPlanarVideoRange",
+        kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange: "Lossy_420YpCbCr8BiPlanarFullRange",
+        kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarVideoRange: "Lossy_420YpCbCr8BiPlanarVideoRange",
+        kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarFullRange: "Lossy_422YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarVideoRange: "Lossy_422YpCbCr10PackedBiPlanarVideoRange",
+        kCVPixelFormatType_OneComponent10: "OneComponent10",
+        kCVPixelFormatType_OneComponent12: "OneComponent12",
+        kCVPixelFormatType_OneComponent16: "OneComponent16",
+        kCVPixelFormatType_OneComponent16Half: "OneComponent16Half",
+        kCVPixelFormatType_OneComponent32Float: "OneComponent32Float",
+        kCVPixelFormatType_OneComponent8: "OneComponent8",
+        kCVPixelFormatType_TwoComponent16: "TwoComponent16",
+        kCVPixelFormatType_TwoComponent16Half: "TwoComponent16Half",
+        kCVPixelFormatType_TwoComponent32Float: "TwoComponent32Float",
+        kCVPixelFormatType_TwoComponent8: "TwoComponent8",
+        
+        kCVPixelFormatType_420YpCbCr10PackedBiPlanarFullRange: "420YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_422YpCbCr10PackedBiPlanarFullRange: "kCVPixelFormatType_422YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_444YpCbCr10PackedBiPlanarFullRange: "kCVPixelFormatType_444YpCbCr10PackedBiPlanarFullRange",
+        kCVPixelFormatType_420YpCbCr10PackedBiPlanarVideoRange: "kCVPixelFormatType_420YpCbCr10PackedBiPlanarVideoRange",
+        kCVPixelFormatType_422YpCbCr10PackedBiPlanarVideoRange: "kCVPixelFormatType_422YpCbCr10PackedBiPlanarVideoRange",
+        kCVPixelFormatType_444YpCbCr10PackedBiPlanarVideoRange: "kCVPixelFormatType_444YpCbCr10PackedBiPlanarVideoRange",
+        
+        // Internal formats?
+        0x61766331: "NonDescriptH264",
+        0x68766331: "NonDescriptHVC1"
+    ]
+    
+    // Get bits per component for video format
+    static func getBpcForVideoFormat(_ videoFormat: CMFormatDescription) -> Int {
+        let bpcRaw = videoFormat.extensions["BitsPerComponent" as CFString]
+        return (bpcRaw != nil ? bpcRaw as! NSNumber : 8).intValue
+    }
+    
+    // Returns true if video format is full-range
+    static func getIsFullRangeForVideoFormat(_ videoFormat: CMFormatDescription) -> Bool {
+        let isFullVideoRaw = videoFormat.extensions["FullRangeVideo" as CFString]
+        return ((isFullVideoRaw != nil ? isFullVideoRaw as! NSNumber : 0).intValue != 0)
+    }
+    
+    // The Metal texture formats for each of the planes of a given CVPixelFormatType
+    static func getTextureTypesForFormat(_ format: OSType) -> [MTLPixelFormat]
+    {
+        // TODO(shinyquagsire23): I still haven't figured out how to determine if a pixel format
+        // is valid on a particular hardware configuration, Metal throws asserts for invalid formats
+        switch(format) {
+            // 8-bit biplanar
+            case kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
+                return forceFastSecretTextureFormats ? [MTLPixelFormat.init(rawValue: MTLPixelFormatYCBCR8_420_2P_sRGB)!, MTLPixelFormat.invalid] : [MTLPixelFormat.r8Unorm, MTLPixelFormat.rg8Unorm]
+
+            // 10-bit biplanar
+            case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+                 kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange,
+                 kCVPixelFormatType_422YpCbCr10BiPlanarFullRange,
+                 kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange,
+                 kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+                return forceFastSecretTextureFormats ? [MTLPixelFormat.init(rawValue: MTLPixelFormatYCBCR10_420_2P_sRGB)!, MTLPixelFormat.invalid] : [MTLPixelFormat.r16Unorm, MTLPixelFormat.rg16Unorm]
+
+            //
+            // If it's good enough for WebKit, it's good enough for me.
+            // https://github.com/WebKit/WebKit/blob/f86d3400c875519b3f3c368f1ea9a37ed8a1d11b/Source/WebGPU/WebGPU/MetalSPI.h#L30
+            // https://github.com/WebKit/WebKit/blob/f86d3400c875519b3f3c368f1ea9a37ed8a1d11b/Source/WebGPU/WebGPU/BindGroup.mm#L43
+            // https://github.com/WebKit/WebKit/blob/ef1916c078676dca792cef30502a765d398dcc18/Source/WebGPU/WebGPU/BindGroup.mm#L416
+            //
+            // 10-bit packed biplanar 4:2:0
+            case kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarFullRange_compat,
+                 kCVPixelFormatType_420YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr10PackedBiPlanarVideoRange:
+                return [MTLPixelFormat.init(rawValue: MTLPixelFormatYCBCR10_420_2P_PACKED_sRGB)!, MTLPixelFormat.invalid] // MTLPixelFormatYCBCR10_420_2P_PACKED
+            
+            // 10-bit packed biplanar 4:2:2
+            case kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr10PackedBiPlanarVideoRange:
+                return [MTLPixelFormat.init(rawValue: MTLPixelFormatYCBCR10_422_2P_PACKED_sRGB)!, MTLPixelFormat.invalid] // MTLPixelFormatYCBCR10_422_2P_PACKED
+            
+            // 10-bit packed biplanar 4:4:4
+            case kCVPixelFormatType_444YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_444YpCbCr10PackedBiPlanarVideoRange:
+                return [MTLPixelFormat.init(rawValue: MTLPixelFormatYCBCR10_444_2P_PACKED_sRGB)!, MTLPixelFormat.invalid] // MTLPixelFormatYCBCR10_444_2P_PACKED
+            
+            // RGB formats
+            case kCVPixelFormatType_32BGRA,
+                 kCVPixelFormatType_Lossless_32BGRA,
+                 kCVPixelFormatType_Lossy_32BGRA:
+                return [MTLPixelFormat.bgra8Unorm_srgb, MTLPixelFormat.invalid]
+            case kCVPixelFormatType_32RGBA:
+                return [MTLPixelFormat.rgba8Unorm_srgb, MTLPixelFormat.invalid]
+
+            // Guess 8-bit biplanar otherwise
+            default:
+                let formatStr = coreVideoPixelFormatToStr[format, default: "unknown"]
+                print("Warning: Pixel format \(formatStr) (\(format)) is not currently accounted for! Returning 8-bit vals")
+                return [MTLPixelFormat.r8Unorm, MTLPixelFormat.rg8Unorm]
+        }
+    }
+    
+    static func isFormatSecret(_ format: OSType) -> Bool
+    {
+        switch(format) {
+            // Packed formats, requires secret MTLTexture pixel formats
+            case kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_420YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr10PackedBiPlanarFullRange_compat,
+                 kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_422YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_422YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_444YpCbCr10PackedBiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_422YpCbCr10PackedBiPlanarVideoRange,
+                 kCVPixelFormatType_444YpCbCr10PackedBiPlanarVideoRange:
+            return true;
+            
+            // Not packed, but there's still a nice pixel format for them that's a
+            // few hundred microseconds faster.
+            case kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarVideoRange, // 8-bit
+                 kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_Lossy_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                 kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange,
+                 kCVPixelFormatType_444YpCbCr8BiPlanarFullRange,
+                 
+                 // 10-bit
+                 kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+                 kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
+                 kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange,
+                 kCVPixelFormatType_422YpCbCr10BiPlanarFullRange,
+                 kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange,
+                 kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+                return forceFastSecretTextureFormats
+            default:
+                return false
+        }
+    }
+}

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -38,7 +38,6 @@ let decodingFormat = kCVPixelFormatType_Lossless_32BGRA
 // #define BUFFER_TYPE_PICDATA ...
 // etc.
 
-
 // MARK: - VideoDecoderRenderer
 @objc
 class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
@@ -149,7 +148,9 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
         let mtlTexture = CVMetalTextureGetTexture(imageTexture!)!
         
         blits.copy(from: mtlTexture, to: drawable.texture)
+        blits.generateMipmaps(for: drawable.texture)
         blits.endEncoding()
+
         commandBuffer.commit()
         commandBuffer.waitUntilCompleted()
         drawable.present()
@@ -167,8 +168,8 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
                     pixelFormat: metalFormat,
                     width: Int(videoWidth),
                     height: Int(videoHeight),
-                    usage: [.renderTarget, .shaderRead, .shaderWrite],
-                    mipmapsMode: .none
+                    usage: [.renderTarget], // .renderTarget only, so that we get framebuffer compression
+                    mipmapsMode: .allocateAll // shinyquagsire23: Wasteful bc we probably only need like 2, but we don't have a choice here.
                 )
                 do {
                     let queue = try TextureResource.DrawableQueue(descriptor)
@@ -192,9 +193,9 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
                 desc.height = Int(videoHeight)
                 desc.depth = 1
                 
-                desc.mipmapLevelCount = 1
+                desc.mipmapLevelCount = 1 // TODO(shinyquagsire23): Maybe 2?
                 desc.pixelFormat = metalFormat //.rgba16Float //.rgba16Float // .rg8Unorm //.r8Unorm// .bgra8Unorm
-                desc.textureUsage = [.shaderRead, .shaderWrite, .renderTarget]
+                desc.textureUsage = [.renderTarget] // .renderTarget only, so that we get framebuffer compression
                 desc.swizzle = .init(red: .red, green: .green, blue: .blue, alpha: .alpha)
                 
                 
@@ -327,6 +328,9 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
                 self.formatDesc = formatDesc
                 // rgba16Float
                 let videoDecoderSpecification:[NSString: AnyObject] = [kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder:kCFBooleanTrue]
+                // TODO(shinyquagsire23): Setting kCVPixelBufferPixelFormatTypeKey *at all* will trigger
+                // a VideoToolbox bug that results in the output CVPixelBuffer's underlying Metal textures
+                // being decompressed, resulting in GPU bandwidth penalties
                 let attributes = [kCVPixelBufferPixelFormatTypeKey : decodingFormat /*kCVPixelFormatType_32BGRA , kCVPixelFormatType_420YpCbCr8BiPlanarFullRange*/, kCVPixelBufferMetalCompatibilityKey: true, kCVPixelBufferPoolMinimumBufferCountKey: 3] as CFDictionary
                 VTDecompressionSessionCreate(allocator: kCFAllocatorDefault, formatDescription: formatDesc, decoderSpecification: videoDecoderSpecification as CFDictionary, imageBufferAttributes: attributes, outputCallback: &self.decoderCallback, decompressionSessionOut: &self.session)
             } else {

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -578,59 +578,33 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
         formatDesc: CMVideoFormatDescription,
         decodeUnit: PDECODE_UNIT!
     ) -> CMSampleBuffer? {
-
-        // Create block buffer from data
-        var dataBlockBuffer: CMBlockBuffer?
-        let statusDataBlock = CMBlockBufferCreateWithMemoryBlock(
-            allocator: nil,
-            memoryBlock: dataPtr,
-            blockLength: length,
-            blockAllocator: kCFAllocatorDefault,
-            customBlockSource: nil,
-            offsetToData: 0,
-            dataLength: length,
-            flags: 0,
-            blockBufferOut: &dataBlockBuffer
-        )
-        if statusDataBlock != kCMBlockBufferNoErr {
-            print("CMBlockBufferCreateWithMemoryBlock failed: \(statusDataBlock)")
-            return nil
-        }
-        // Now the CMBlockBuffer controls freeing `dataPtr`
-
         // Create an empty container block for rewriting AnnexB to length-delimited if needed
         var frameBlockBuffer: CMBlockBuffer?
-        let statusFrameBlock = CMBlockBufferCreateEmpty(
-            allocator: nil,
-            capacity: 0,
-            flags: 0,
-            blockBufferOut: &frameBlockBuffer
-        )
-        if statusFrameBlock != kCMBlockBufferNoErr {
-            print("CMBlockBufferCreateEmpty failed: \(statusFrameBlock)")
-            return nil
-        }
 
         // If H.264/HEVC, rewrite from AnnexB to length-delimited
         if (videoFormat & (VIDEO_FORMAT_MASK_H264 | VIDEO_FORMAT_MASK_H265)) != 0 {
-            rewriteAnnexBToLengthDelimited(
-                frameBlockBuffer: frameBlockBuffer!,
-                dataBlockBuffer: dataBlockBuffer!,
-                totalLength: length
-            )
+            // dataPtr is either tied to the resulting BB, or is copied and freed immediately.
+            // dataPtr is also freed even if the result is nil.
+            let nals = UnsafeMutableBufferPointer<UInt8>(start: UnsafeMutablePointer(mutating: dataPtr), count: length)
+            frameBlockBuffer = annexBBufferToCMSampleBuffer(buffer: nals, videoFormat: formatDesc)
         } else {
             // AV1 or other codecs that don’t need rewriting
-            let statusRef = CMBlockBufferAppendBufferReference(
-                frameBlockBuffer!,
-                targetBBuf: dataBlockBuffer!,
+            let statusDataBlock = CMBlockBufferCreateWithMemoryBlock(
+                allocator: nil,
+                memoryBlock: dataPtr,
+                blockLength: length,
+                blockAllocator: kCFAllocatorDefault,
+                customBlockSource: nil,
                 offsetToData: 0,
                 dataLength: length,
-                flags: 0
+                flags: 0,
+                blockBufferOut: &frameBlockBuffer
             )
-            if statusRef != kCMBlockBufferNoErr {
-                print("CMBlockBufferAppendBufferReference failed: \(statusRef)")
+            if statusDataBlock != kCMBlockBufferNoErr {
+                print("CMBlockBufferCreateWithMemoryBlock failed: \(statusDataBlock)")
                 return nil
             }
+            // Now the CMBlockBuffer controls freeing `dataPtr`
         }
 
         // Build the sample buffer
@@ -665,104 +639,143 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
 
         return sampleBuffer
     }
-
-    /// Rewrites the given data from Annex-B format to length-delimited for H.264/HEVC
-    private func rewriteAnnexBToLengthDelimited(
-        frameBlockBuffer: CMBlockBuffer,
-        dataBlockBuffer: CMBlockBuffer,
-        totalLength: Int
-    ) {
-        // NALU start prefix size is 3 or 4 bytes. 
-        // The code finds start codes, then appends length prefixes instead.
-        let dataPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: totalLength)
-        defer { dataPtr.deallocate() }
-
-        // We read out the original data
-        CMBlockBufferCopyDataBytes(dataBlockBuffer, atOffset: 0, dataLength: totalLength, destination: dataPtr)
-
-        var lastOffset = -1
-        for i in 0..<(totalLength - NALU_START_PREFIX_SIZE) {
-            // Search for 00 00 01
-            if dataPtr[i] == 0 && dataPtr[i+1] == 0 && dataPtr[i+2] == 1 {
-                // Found a new NALU start
-                if lastOffset != -1 {
-                    updateAnnexBBuffer(
-                        frameBlockBuffer: frameBlockBuffer,
-                        dataBlockBuffer: dataBlockBuffer,
-                        offset: lastOffset,
-                        length: i - lastOffset
-                    )
+    
+    // Based on https://webrtc.googlesource.com/src/+/refs/heads/main/common_video/h264/h264_common.cc
+    private func findNaluIndices(bufferBounded: UnsafeMutableBufferPointer<UInt8>) -> ([NaluIndex], Bool) {
+        var elgibleForModifyInPlace = true
+        guard bufferBounded.count >= /* kNaluShortStartSequenceSize */ 3 else {
+            return ([], false)
+        }
+        
+        var sequences = [NaluIndex]()
+        
+        let end = bufferBounded.count - /* kNaluShortStartSequenceSize */ 3
+        var i = 0
+        let buffer = Data(bytesNoCopy: bufferBounded.baseAddress!, count: bufferBounded.count, deallocator: .none) // ?? why is this faster
+        while i < end {
+            if buffer[i + 2] > 1 {
+                i += 3
+            } else if buffer[i + 2] == 1 {
+                if buffer[i + 1] == 0 && buffer[i] == 0 {
+                    var index = NaluIndex(startOffset: i, payloadStartOffset: i + 3, payloadSize: 0, threeByteHeader: true)
+                    if index.startOffset > 0 && buffer[index.startOffset - 1] == 0 {
+                        index.startOffset -= 1
+                        index.threeByteHeader = false
+                    }
+                    else {
+                        elgibleForModifyInPlace = false
+                    }
+                    
+                    if !sequences.isEmpty {
+                        sequences[sequences.count - 1].payloadSize = index.startOffset - sequences.last!.payloadStartOffset
+                    }
+                    
+                    sequences.append(index)
                 }
-                lastOffset = i
+                
+                i += 3
+            } else {
+                i += 1
             }
         }
-
-        if lastOffset != -1 {
-            // Append the last chunk
-            updateAnnexBBuffer(
-                frameBlockBuffer: frameBlockBuffer,
-                dataBlockBuffer: dataBlockBuffer,
-                offset: lastOffset,
-                length: totalLength - lastOffset
-            )
+        
+        if !sequences.isEmpty {
+            sequences[sequences.count - 1].payloadSize = bufferBounded.count - sequences.last!.payloadStartOffset
+        }
+        
+        return (sequences, elgibleForModifyInPlace)
+    }
+    
+    private struct NaluIndex {
+        var startOffset: Int
+        var payloadStartOffset: Int
+        var payloadSize: Int
+        var threeByteHeader: Bool
+    }
+    
+    // Based on https://webrtc.googlesource.com/src/+/refs/heads/main/sdk/objc/components/video_codec/nalu_rewriter.cc
+    private func annexBBufferToCMSampleBuffer(buffer: UnsafeMutableBufferPointer<UInt8>, videoFormat: CMFormatDescription) -> CMBlockBuffer? {
+        let (naluIndices, elgibleForModifyInPlace) = findNaluIndices(bufferBounded: buffer)
+        
+        if elgibleForModifyInPlace {
+            return annexBBufferToCMSampleBufferModifyInPlace(buffer: buffer, videoFormat: videoFormat, naluIndices: naluIndices)
+        }
+        else {
+            return annexBBufferToCMSampleBufferWithCopy(buffer: buffer, videoFormat: videoFormat, naluIndices: naluIndices)
         }
     }
+    
+    private func annexBBufferToCMSampleBufferWithCopy(buffer: UnsafeMutableBufferPointer<UInt8>, videoFormat: CMFormatDescription, naluIndices: [NaluIndex]) -> CMBlockBuffer? {
+        var err: OSStatus = 0
+        defer { buffer.deallocate() }
 
-    /// This function does the final rewriting step for each found NALU
-    private func updateAnnexBBuffer(
-        frameBlockBuffer: CMBlockBuffer,
-        dataBlockBuffer: CMBlockBuffer,
-        offset: Int,
-        length: Int
-    ) {
-        // Insert the 4-byte length prefix instead of start code
-        let oldOffset = CMBlockBufferGetDataLength(frameBlockBuffer)
-        let statusAppend = CMBlockBufferAppendMemoryBlock(
-            frameBlockBuffer,
-            memoryBlock: nil,
-            length: NAL_LENGTH_PREFIX_SIZE,
-            blockAllocator: kCFAllocatorDefault,
-            customBlockSource: nil,
-            offsetToData: 0,
-            dataLength: NAL_LENGTH_PREFIX_SIZE,
-            flags: 0
-        )
-        if statusAppend != noErr {
-            print("CMBlockBufferAppendMemoryBlock failed: \(statusAppend)")
-            return
+        // we're replacing the 3/4 nalu headers with a 4 byte length, so add an extra byte on top of the original length for each 3-byte nalu header
+        let blockBufferLength = buffer.count + naluIndices.filter(\.threeByteHeader).count
+        let blockBuffer = try! CMBlockBuffer(length: blockBufferLength, flags: .assureMemoryNow)
+        
+        var contiguousBuffer: CMBlockBuffer!
+        if !CMBlockBufferIsRangeContiguous(blockBuffer, atOffset: 0, length: 0) {
+            err = CMBlockBufferCreateContiguous(allocator: nil, sourceBuffer: blockBuffer, blockAllocator: nil, customBlockSource: nil, offsetToData: 0, dataLength: 0, flags: 0, blockBufferOut: &contiguousBuffer)
+            if err != 0 {
+                print("CMBlockBufferCreateContiguous error")
+                return nil
+            }
+        } else {
+            contiguousBuffer = blockBuffer
         }
-
-        // The new length (strip out the start code bytes)
-        let dataLength = length - NALU_START_PREFIX_SIZE
-        let lengthBytes: [UInt8] = [
-            UInt8((dataLength >> 24) & 0xFF),
-            UInt8((dataLength >> 16) & 0xFF),
-            UInt8((dataLength >> 8) & 0xFF),
-            UInt8(dataLength & 0xFF)
-        ]
-
-        let statusReplace = CMBlockBufferReplaceDataBytes(
-            with: lengthBytes,
-            blockBuffer: frameBlockBuffer,
-            offsetIntoDestination: oldOffset,
-            dataLength: NAL_LENGTH_PREFIX_SIZE
-        )
-        if statusReplace != noErr {
-            print("CMBlockBufferReplaceDataBytes failed: \(statusReplace)")
-            return
+        
+        var blockBufferSize = 0
+        var dataPtr: UnsafeMutablePointer<Int8>!
+        err = CMBlockBufferGetDataPointer(contiguousBuffer, atOffset: 0, lengthAtOffsetOut: nil, totalLengthOut: &blockBufferSize, dataPointerOut: &dataPtr)
+        if err != 0 {
+            print("CMBlockBufferGetDataPointer error")
+            return nil
         }
+        
+        let pointer = UnsafeMutablePointer<UInt8>(OpaquePointer(dataPtr))!
+        var offset = 0
+        
+        buffer.withUnsafeBytes { (unsafeBytes) in
+            let bytes = unsafeBytes.bindMemory(to: UInt8.self).baseAddress!
 
-        // Attach the data buffer by reference
-        let statusRef = CMBlockBufferAppendBufferReference(
-            frameBlockBuffer,
-            targetBBuf: dataBlockBuffer,
-            offsetToData: offset + NALU_START_PREFIX_SIZE,
-            dataLength: dataLength,
-            flags: 0
-        )
-        if statusRef != noErr {
-            print("CMBlockBufferAppendBufferReference failed: \(statusRef)")
+            for index in naluIndices {
+                pointer.advanced(by: offset    ).pointee = UInt8((index.payloadSize >> 24) & 0xFF)
+                pointer.advanced(by: offset + 1).pointee = UInt8((index.payloadSize >> 16) & 0xFF)
+                pointer.advanced(by: offset + 2).pointee = UInt8((index.payloadSize >>  8) & 0xFF)
+                pointer.advanced(by: offset + 3).pointee = UInt8((index.payloadSize      ) & 0xFF)
+                offset += 4
+                
+                pointer.advanced(by: offset).update(from: bytes.advanced(by: index.payloadStartOffset), count: blockBufferSize - offset)
+                offset += index.payloadSize
+            }
         }
+        
+        return contiguousBuffer
+    }
+    
+    private func annexBBufferToCMSampleBufferModifyInPlace(buffer: UnsafeMutableBufferPointer<UInt8>, videoFormat: CMFormatDescription, naluIndices: [NaluIndex]) -> CMBlockBuffer? {
+        var err: OSStatus = 0
+        var offset = 0
+
+        let umrbp = UnsafeMutableRawBufferPointer(start: buffer.baseAddress, count: buffer.count)
+        let bb = try! CMBlockBuffer.init(buffer: umrbp, deallocator: {(_, _) in /*buffer.deallocate()*/ }, flags: .assureMemoryNow)
+
+        let pointer = UnsafeMutablePointer<UInt8>(OpaquePointer(buffer.baseAddress!))!
+        for index in naluIndices {
+            pointer.advanced(by: offset+0).pointee = UInt8((index.payloadSize >> 24) & 0xFF)
+            pointer.advanced(by: offset+1).pointee = UInt8((index.payloadSize >> 16) & 0xFF)
+            pointer.advanced(by: offset+2).pointee = UInt8((index.payloadSize >>  8) & 0xFF)
+            pointer.advanced(by: offset+3).pointee = UInt8((index.payloadSize      ) & 0xFF)
+            offset += 4
+            
+            offset += index.payloadSize
+        }
+        
+        if bb == nil {
+            buffer.deallocate()
+        }
+        
+        return bb
     }
 
     // MARK: - Rendering to the Drawable

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -754,11 +754,10 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
     }
     
     private func annexBBufferToCMSampleBufferModifyInPlace(buffer: UnsafeMutableBufferPointer<UInt8>, videoFormat: CMFormatDescription, naluIndices: [NaluIndex]) -> CMBlockBuffer? {
-        var err: OSStatus = 0
         var offset = 0
 
         let umrbp = UnsafeMutableRawBufferPointer(start: buffer.baseAddress, count: buffer.count)
-        let bb = try! CMBlockBuffer.init(buffer: umrbp, deallocator: {(_, _) in /*buffer.deallocate()*/ }, flags: .assureMemoryNow)
+        let bb = try! CMBlockBuffer.init(buffer: umrbp, deallocator: {(_, _) in buffer.deallocate() }, flags: .assureMemoryNow)
 
         let pointer = UnsafeMutablePointer<UInt8>(OpaquePointer(buffer.baseAddress!))!
         for index in naluIndices {

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -16,12 +16,7 @@ import RealityKit
 import VideoToolbox
 import Metal
 
-// https://gist.github.com/shinyquagsire23/81c86f4bf670aaa68b5804080ff964a0
-let MTLPixelFormatYCBCR8_420_2P_sRGB: UInt = 520
-let MTLPixelFormatBGRA10_XR: UInt = 552
-let FORMAT: [MTLPixelFormat] = [MTLPixelFormat.init(rawValue: MTLPixelFormatYCBCR8_420_2P_sRGB)!, MTLPixelFormat.invalid]
-
-let metalFormat: MTLPixelFormat = .bgra8Unorm_srgb
+let metalFormat: MTLPixelFormat = .rgba16Float //.bgra8Unorm_srgb
 /*kCVPixelFormatType_32BGRA , kCVPixelFormatType_420YpCbCr8BiPlanarFullRange*/
 let decodingFormat = kCVPixelFormatType_Lossless_32BGRA
 // MARK: - External C references (from bridging header)
@@ -93,6 +88,9 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
         
         private var renderPipelineState: MTLComputePipelineState?
         private var imagePlaneVertexBuffer: MTLBuffer?
+    
+    private var copyPipelineState: MTLRenderPipelineState?
+    private var copyPipelineFormat: MTLPixelFormat?
 
     // MARK: - Initialization
 
@@ -125,17 +123,40 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
             let imageBuffer = imageBuffer,
             let drawable = try? self.drawableQueue?.nextDrawable(),
             let commandBuffer = commandQueue?.makeCommandBuffer(),
-            var textureCache = self.textureCache,
-            let blits = commandBuffer.makeBlitCommandEncoder() else {
+            let textureCache = self.textureCache else {
             print("ERROR")
             return
         }
         
-        var planes = CVPixelBufferGetPlaneCount(imageBuffer)
+        // The copy pipeline relines on a fixed output pixel format,
+        // so we have to make sure that matches the render target.
+        if self.copyPipelineState == nil || self.copyPipelineFormat != metalFormat {
+            self.copyPipelineState = self.buildCopyPipeline(metalFormat);
+            if self.copyPipelineState != nil {
+                self.copyPipelineFormat = metalFormat;
+            }
+        }
+        guard let copyPipelineState = self.copyPipelineState else {
+            print("Failed to set up copy render pipeline!")
+            return
+        }
+        
+        // Figure out the Metal pixel format
+        let pixelFormat = CVPixelBufferGetPixelFormatType(imageBuffer);
+        let srcMetalFormats = CVMetalHelpers.getTextureTypesForFormat(pixelFormat)
+        if srcMetalFormats[1] != MTLPixelFormat.invalid {
+            print("TODO split planes")
+            return
+        }
+        let srcMetalFormat = srcMetalFormats[0];
+        
+        let numPlanes = CVPixelBufferGetPlaneCount(imageBuffer)
         //            print("Image with planes: \(planes)")
         var imageTexture: CVMetalTexture?
         let width = CVPixelBufferGetWidth(imageBuffer)
         let height = CVPixelBufferGetHeight(imageBuffer)
+        let planeWidth = CVPixelBufferGetWidthOfPlane(imageBuffer, 0)
+        let planeHeight = CVPixelBufferGetHeightOfPlane(imageBuffer, 0)
         
         if (width != videoWidth || height != videoHeight) {
             print("Got video frame with mismatching dimensions \(width)x\(height) (client texture dimensions \(videoWidth)x\(videoHeight)) - correcting")
@@ -144,15 +165,51 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
             self.setupLowLevelTexture()
         }
         // kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
-        let result = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, textureCache, imageBuffer, nil, metalFormat /*bgra8Unorm*/, width, height, 0, &imageTexture)
+        let result = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault, textureCache, imageBuffer, nil, srcMetalFormat /*bgra8Unorm*/, planeWidth, planeHeight, 0, &imageTexture)
+        if result != 0 {
+            print("CVMetalTextureCacheCreateTextureFromImage \(result)")
+            return
+        }
         let mtlTexture = CVMetalTextureGetTexture(imageTexture!)!
         
-        blits.copy(from: mtlTexture, to: drawable.texture)
-        blits.generateMipmaps(for: drawable.texture)
-        blits.endEncoding()
+        /*
+        NSLog(mtlTexture.debugDescription!)
+        if !((mtlTexture.debugDescription?.contains("decompressedPixelFormat") ?? true) || (mtlTexture.debugDescription?.contains("isCompressed = 1") ?? true)) {
+            NSLog("NO COMPRESSION ON VT FRAME!!!! AAAAAAAAA!! RIP BANDWIDTH!!")
+        }
+        */
+        
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        renderPassDescriptor.colorAttachments[0].texture = drawable.texture
+        renderPassDescriptor.colorAttachments[0].loadAction = .clear
+        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        
+        guard let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else {
+            fatalError("Failed to create render command encoder")
+        }
+        renderEncoder.setRenderPipelineState(copyPipelineState)
+        renderEncoder.setFragmentTexture(mtlTexture, index: 0)
+        renderEncoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        renderEncoder.endEncoding()
 
         commandBuffer.commit()
         commandBuffer.waitUntilCompleted()
+        
+        // I'm not sure why I can't encode these into the same command buffer to be honest
+        // (Maybe I need a fence?)
+        guard let commandBufferBlit = commandQueue?.makeCommandBuffer(),
+            let blits = commandBufferBlit.makeBlitCommandEncoder() else {
+            print("ERROR")
+            return
+        }
+        
+        //blits.copy(from: mtlTexture, to: drawable.texture)
+        blits.generateMipmaps(for: drawable.texture)
+        blits.endEncoding()
+
+        commandBufferBlit.commit()
+        commandBufferBlit.waitUntilCompleted()
+        
         drawable.present()
     }
     
@@ -328,11 +385,14 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
                 self.formatDesc = formatDesc
                 // rgba16Float
                 let videoDecoderSpecification:[NSString: AnyObject] = [kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder:kCFBooleanTrue]
-                // TODO(shinyquagsire23): Setting kCVPixelBufferPixelFormatTypeKey *at all* will trigger
+                // NOTE(shinyquagsire23): Setting kCVPixelBufferPixelFormatTypeKey *at all* will trigger
                 // a VideoToolbox bug that results in the output CVPixelBuffer's underlying Metal textures
                 // being decompressed, resulting in GPU bandwidth penalties
-                let attributes = [kCVPixelBufferPixelFormatTypeKey : decodingFormat /*kCVPixelFormatType_32BGRA , kCVPixelFormatType_420YpCbCr8BiPlanarFullRange*/, kCVPixelBufferMetalCompatibilityKey: true, kCVPixelBufferPoolMinimumBufferCountKey: 3] as CFDictionary
-                VTDecompressionSessionCreate(allocator: kCFAllocatorDefault, formatDescription: formatDesc, decoderSpecification: videoDecoderSpecification as CFDictionary, imageBufferAttributes: attributes, outputCallback: &self.decoderCallback, decompressionSessionOut: &self.session)
+                var attributes: [CFString : Any] = [kCVPixelBufferMetalCompatibilityKey: true, kCVPixelBufferPoolMinimumBufferCountKey: 3]
+                if !forceFastSecretTextureFormats {
+                    attributes[kCVPixelBufferPixelFormatTypeKey] = decodingFormat
+                }
+                VTDecompressionSessionCreate(allocator: kCFAllocatorDefault, formatDescription: formatDesc, decoderSpecification: videoDecoderSpecification as CFDictionary, imageBufferAttributes: attributes as CFDictionary, outputCallback: &self.decoderCallback, decompressionSessionOut: &self.session)
             } else {
                 // Couldn’t create format description yet
 //                free(dataPtr)
@@ -776,6 +836,26 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
         }
     }
     
+    // Builds a simple copy pipeline with no input buffers, just
+    // draw 4 vertices to copy the input texture to the output
+    private func buildCopyPipeline(_ srcColorFormat: MTLPixelFormat) -> MTLRenderPipelineState? {
+        guard
+            let library = mtlDevice.makeDefaultLibrary()
+        else {
+            return nil
+        }
+        let vertexFunction = library.makeFunction(name: "copyVertexShader")
+        let fragmentFunction = library.makeFunction(name: "copyFragmentShader")
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.label = "CopyBlitPipeline"
+        pipelineDescriptor.vertexFunction = vertexFunction
+        pipelineDescriptor.fragmentFunction = fragmentFunction
+        pipelineDescriptor.colorAttachments[0].pixelFormat = srcColorFormat
+        pipelineDescriptor.colorAttachments[0].isBlendingEnabled = false
+        pipelineDescriptor.maxVertexAmplificationCount = 1
+        
+        return try? mtlDevice.makeRenderPipelineState(descriptor: pipelineDescriptor)
+    }
     
     // MARK: - METAL
     private func initializeRenderPipelineState() {

--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -62,7 +62,7 @@ struct RealityKitStreamView: View {
         let data = Data.init(count: 4 * Int(streamConfig.wrappedValue.width) * Int(streamConfig.wrappedValue.height)) // Dummy data
         self.texture = try! TextureResource(
             dimensions: .dimensions(width: Int(streamConfig.wrappedValue.width), height: Int(streamConfig.wrappedValue.height)),
-            format: .raw(pixelFormat: metalFormat),
+            format: .raw(pixelFormat: .bgra8Unorm_srgb), // Doesn't matter, dummy data
             contents: .init(
                 mipmapLevels: [
                     .mip(data: data, bytesPerRow: 4 * Int(streamConfig.wrappedValue.width) ), // TODO is this even needed

--- a/Moonlight Vision/Shaders.metal
+++ b/Moonlight Vision/Shaders.metal
@@ -1,0 +1,34 @@
+//
+//  Shaders.metal
+//  Moonlight
+//
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct CopyVertexOut {
+    float4 position [[position]];
+    float2 uv;
+};
+
+vertex CopyVertexOut copyVertexShader(ushort vertexID [[vertex_id]]) {
+    CopyVertexOut out;
+    float2 uv = float2(float((vertexID << ushort(1)) & 2u), float(vertexID & ushort(2)) * 0.5);
+    out.position = float4((uv * float2(2.0, -2.0)) + float2(-1.0, 1.0), 0.0, 1.0);
+    out.uv = uv;
+    return out;
+}
+
+fragment half4 copyFragmentShader(CopyVertexOut in [[stage_in]], texture2d<half> in_tex) {
+    constexpr sampler colorSampler(coord::normalized,
+                    address::clamp_to_edge,
+                    filter::linear);
+
+    half4 color = in_tex.sample(colorSampler, in.uv);
+
+    return color;
+}

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		B1EDB13D2D4D95BF00EB1839 /* StreamConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EDB13B2D4D95BF00EB1839 /* StreamConfiguration.swift */; };
 		B1EDB13E2D4D95BF00EB1839 /* StreamConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EDB13B2D4D95BF00EB1839 /* StreamConfiguration.swift */; };
 		DC1F5A07206436B20037755F /* ConnectionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1F5A06206436B20037755F /* ConnectionHelper.m */; };
+		E77582CD2D53F3EB00948545 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E77582CC2D53F3E500948545 /* Shaders.metal */; };
+		E77582CF2D54020700948545 /* CVMetalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77582CE2D54020300948545 /* CVMetalHelpers.swift */; };
 		F71801422B65483D00A9336B /* AppsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71801412B65483D00A9336B /* AppsView.swift */; };
 		F71801442B654D9100A9336B /* TemporaryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71801432B654D9100A9336B /* TemporaryApp.swift */; };
 		F71801452B65583700A9336B /* TemporaryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71801432B654D9100A9336B /* TemporaryApp.swift */; };
@@ -327,6 +329,8 @@
 		D4746EEA1CBC740C006FB401 /* Moonlight-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Moonlight-Bridging-Header.h"; path = "Input/Moonlight-Bridging-Header.h"; sourceTree = "<group>"; };
 		DC1F5A05206436B10037755F /* ConnectionHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConnectionHelper.h; sourceTree = "<group>"; };
 		DC1F5A06206436B20037755F /* ConnectionHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConnectionHelper.m; sourceTree = "<group>"; };
+		E77582CC2D53F3E500948545 /* Shaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
+		E77582CE2D54020300948545 /* CVMetalHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVMetalHelpers.swift; sourceTree = "<group>"; };
 		F71801412B65483D00A9336B /* AppsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsView.swift; sourceTree = "<group>"; };
 		F71801432B654D9100A9336B /* TemporaryApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryApp.swift; sourceTree = "<group>"; };
 		F71801492B655C1F00A9336B /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -635,7 +639,9 @@
 		F7A119592B5DE1AB001E8686 /* Moonlight Vision */ = {
 			isa = PBXGroup;
 			children = (
+				E77582CC2D53F3E500948545 /* Shaders.metal */,
 				3E86FC1C2D4FFDED0016BB8E /* UpdatesView.swift */,
+				E77582CE2D54020300948545 /* CVMetalHelpers.swift */,
 				B1EDB1302D4D95A700EB1839 /* DrawableVideoDecoder.swift */,
 				B1EDB1312D4D95A700EB1839 /* ObservableConnectionManager.swift */,
 				B1EDB1322D4D95A700EB1839 /* RealityKitStreamView.swift */,
@@ -1276,6 +1282,7 @@
 				F7199AFB2B72F33000E6D62D /* SettingsView.swift in Sources */,
 				F7A1191B2B5DDF73001E8686 /* HttpResponse.m in Sources */,
 				F718014A2B655C1F00A9336B /* Utils.swift in Sources */,
+				E77582CF2D54020700948545 /* CVMetalHelpers.swift in Sources */,
 				F7A1195B2B5DE1E2001E8686 /* MoonlightVisionApp.swift in Sources */,
 				F7A119212B5DDF73001E8686 /* HttpManager.m in Sources */,
 				F7A1195D2B5DE1FD001E8686 /* MainContentView.swift in Sources */,
@@ -1292,6 +1299,7 @@
 				F7A1192D2B5DDF73001E8686 /* CryptoManager.m in Sources */,
 				F7A1192E2B5DDF73001E8686 /* ConnectionHelper.m in Sources */,
 				B1AC7CF12D4E011B0013B9A3 /* HDRParsingUtils.m in Sources */,
+				E77582CD2D53F3EB00948545 /* Shaders.metal in Sources */,
 				F7A1192F2B5DDF73001E8686 /* PairManager.m in Sources */,
 				F7A119302B5DDF73001E8686 /* HttpRequest.m in Sources */,
 				F7A119312B5DDF73001E8686 /* OnScreenControls.m in Sources */,


### PR DESCRIPTION
Change summary:
 - Set the texture usages to `.renderTarget` only, anything else will result in bandwidth penalties (in this case, a write penalty during the blit, and then a read penalty when Apple's RealityKit renderer reads the buffer back). Currently there is still a read penalty during the blit, due to the last note.
 - Fixed the edge shimmering, unfortunately the only way to handle this is by generating mipmaps which is ~slow, might be worth benchmarking to see if only generating one level for DrawableQueue is worth pursuing?
- Copy-less decoding of VideoToolbox's CVPixelBuffer
- Fixes for HDR (RGBA16F DrawableQueue)
- Modify-in-place/minimal-copying NAL parsing, brings throughput up to 200Mbps in my tests

~~I also added a comment on the VideoToolbox footgun bug that murders performance for no good reason(see also, https://github.com/shinyquagsire23/VideoToolbox-Uncompressed-Textures-Bug). Worth noting, fixing it is basically required for good HDR10 perf unfortunately, because there's no way to read the default packed HDR10 CVPixelFormat w/o private Metal formats. afaict as well, the only way to use the private formats is by doing a full render pass instead of a blit encoding, since the blits expect input format == output format.~~ Apparently `kCVPixelFormatType_Lossless_32BGRA` avoids the bug lol