### PR TITLE
Initial shortcuts support! and some bug fixes

### DIFF
--- a/Limelight/Database/DataManager.h
+++ b/Limelight/Database/DataManager.h
@@ -35,7 +35,7 @@ realitykitRendererAnimateOpening:(BOOL)realitykitRendererAnimateOpening
      realitykitRendererCurvature:(NSNumber*)realitykitRendererCurvature
                   dimPassthrough:(BOOL)dimPassthrough;
 
-- (NSArray*) getHosts;
+- (NSArray<TemporaryHost*>*) getHosts;
 - (void) updateHost:(TemporaryHost*)host;
 - (void) updateAppsForExistingHost:(TemporaryHost *)host;
 - (void) removeHost:(TemporaryHost*)host;

--- a/Limelight/Database/DataManager.m
+++ b/Limelight/Database/DataManager.m
@@ -246,6 +246,7 @@ realitykitRendererAnimateOpening:(BOOL)realitykitRendererAnimateOpening
     NSFetchRequest* fetchRequest = [[NSFetchRequest alloc] init];
     NSEntityDescription* entity = [NSEntityDescription entityForName:entityName inManagedObjectContext:_managedObjectContext];
     [fetchRequest setEntity:entity];
+    [fetchRequest setReturnsObjectsAsFaults:NO]; // >:(
     
     NSError* error;
     fetchedRecords = [_managedObjectContext executeFetchRequest:fetchRequest error:&error];

--- a/Limelight/Input/ControllerSupport.h
+++ b/Limelight/Input/ControllerSupport.h
@@ -9,6 +9,9 @@
 #import "Controller.h"
 #import <UIKit/UIKit.h>
 
+// It's in Swift's hands now
+@class TemporarySettings;
+
 @class StreamConfiguration;
 
 @class OnScreenControls;
@@ -48,7 +51,7 @@
 -(void) setMotionEventState:(uint16_t)controllerNumber motionType:(uint8_t)motionType reportRateHz:(uint16_t)reportRateHz;
 -(void) setControllerLed:(uint16_t)controllerNumber r:(uint8_t)r g:(uint8_t)g b:(uint8_t)b;
 
-+(int) getConnectedGamepadMask:(StreamConfiguration*)streamConfig;
++(int) getConnectedGamepadMask:(StreamConfiguration*)streamConfig settings:(TemporarySettings* _Nullable)settings;
 
 -(NSUInteger) getConnectedGamepadCount;
 

--- a/Limelight/Input/ControllerSupport.m
+++ b/Limelight/Input/ControllerSupport.m
@@ -1256,7 +1256,7 @@ static const double MOUSE_SPEED_DIVISOR = 1.25;
     return count;
 }
 
-+(int) getConnectedGamepadMask:(StreamConfiguration*)streamConfig {
++(int) getConnectedGamepadMask:(StreamConfiguration*)streamConfig settings:(TemporarySettings* _Nullable) settings {
     int mask = 0;
     
     if (streamConfig.multiController) {
@@ -1272,9 +1272,10 @@ static const double MOUSE_SPEED_DIVISOR = 1.25;
         // properly so always report controller 1 if not in MC mode
         mask = 0x1;
     }
-    
-    DataManager* dataMan = [[DataManager alloc] init];
-    TemporarySettings* settings = [dataMan getSettings];
+    if (settings == NULL) {
+        DataManager* dataMan = [[DataManager alloc] init];
+        settings = [dataMan getSettings];
+    }
     OnScreenControlsLevel level = (OnScreenControlsLevel)settings.onscreenControls;
     
     // Even if no gamepads are present, we will always count one if OSC is enabled,
@@ -1283,7 +1284,6 @@ static const double MOUSE_SPEED_DIVISOR = 1.25;
     if (level != OnScreenControlsLevelOff && (![ControllerSupport hasKeyboardOrMouse] || level != OnScreenControlsLevelAuto) && !settings.absoluteTouchMode) {
         mask |= 0x1;
     }
-    
     return mask;
 }
 

--- a/Limelight/Network/AppListResponse.m
+++ b/Limelight/Network/AppListResponse.m
@@ -100,9 +100,7 @@ static const char* TAG_APP_INSTALL_PATH = "AppInstallPath";
                 appInfoNode = appInfoNode->next;
             }
             if (appId != nil) {
-                TemporaryApp* app = [[TemporaryApp alloc] init];
-                app.name = appName;
-                app.id = appId;
+                TemporaryApp* app = [[TemporaryApp alloc] initWithId:appId name:appName];
                 app.hdrSupported = [hdrSupported intValue] != 0;
                 app.installPath = appInstallPath;
                 [_appList addObject:app];

--- a/Limelight/Stream/Connection.m
+++ b/Limelight/Stream/Connection.m
@@ -314,27 +314,37 @@ void ArDecodeAndPlaySample(char* sampleData, int sampleLength)
 
 void ClStageStarting(int stage)
 {
-    [_callbacks stageStarting:LiGetStageName(stage)];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks stageStarting:LiGetStageName(stage)];
+    });
 }
 
 void ClStageComplete(int stage)
 {
-    [_callbacks stageComplete:LiGetStageName(stage)];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks stageComplete:LiGetStageName(stage)];
+    });
 }
 
 void ClStageFailed(int stage, int errorCode)
 {
-    [_callbacks stageFailed:LiGetStageName(stage) withError:errorCode portTestFlags:LiGetPortFlagsFromStage(stage)];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks stageFailed:LiGetStageName(stage) withError:errorCode portTestFlags:LiGetPortFlagsFromStage(stage)];
+    });
 }
 
 void ClConnectionStarted(void)
 {
-    [_callbacks connectionStarted];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks connectionStarted];
+    });
 }
 
 void ClConnectionTerminated(int errorCode)
 {
-    [_callbacks connectionTerminated: errorCode];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks connectionTerminated: errorCode];
+    });
 }
 
 void ClLogMessage(const char* format, ...)
@@ -347,33 +357,45 @@ void ClLogMessage(const char* format, ...)
 
 void ClRumble(unsigned short controllerNumber, unsigned short lowFreqMotor, unsigned short highFreqMotor)
 {
-    [_callbacks rumble:controllerNumber lowFreqMotor:lowFreqMotor highFreqMotor:highFreqMotor];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks rumble:controllerNumber lowFreqMotor:lowFreqMotor highFreqMotor:highFreqMotor];
+    });
 }
 
 void ClConnectionStatusUpdate(int status)
 {
-    [_callbacks connectionStatusUpdate:status];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks connectionStatusUpdate:status];
+    });
 }
 
 void ClSetHdrMode(bool enabled)
 {
-    [renderer setHdrMode:enabled];
-    [_callbacks setHdrMode:enabled];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [renderer setHdrMode:enabled];
+        [_callbacks setHdrMode:enabled];
+    });
 }
 
 void ClRumbleTriggers(uint16_t controllerNumber, uint16_t leftTriggerMotor, uint16_t rightTriggerMotor)
 {
-    [_callbacks rumbleTriggers:controllerNumber leftTrigger:leftTriggerMotor rightTrigger:rightTriggerMotor];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks rumbleTriggers:controllerNumber leftTrigger:leftTriggerMotor rightTrigger:rightTriggerMotor];
+    });
 }
 
 void ClSetMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz)
 {
-    [_callbacks setMotionEventState:controllerNumber motionType:motionType reportRateHz:reportRateHz];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks setMotionEventState:controllerNumber motionType:motionType reportRateHz:reportRateHz];
+    });
 }
 
 void ClSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b)
 {
-    [_callbacks setControllerLed:controllerNumber r:r g:g b:b];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_callbacks setControllerLed:controllerNumber r:r g:g b:b];
+    });
 }
 
 -(void) terminate

--- a/Limelight/Stream/StreamConfiguration.swift
+++ b/Limelight/Stream/StreamConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objcMembers
-class StreamConfiguration: NSObject, Codable {
+class StreamConfiguration: NSObject, Encodable, Decodable {
     var host: String!
     var httpsPort: UInt16
     var appVersion: String

--- a/Limelight/Stream/StreamManager.m
+++ b/Limelight/Stream/StreamManager.m
@@ -138,8 +138,10 @@
     [hMan executeRequestSynchronously:[HttpRequest requestForResponse:resumeResp withUrlRequest:[hMan newLaunchOrResumeRequest:@"resume" config:_config]]];
     NSString* resume = [resumeResp getStringTag:@"resume"];
     if (![resumeResp isStatusOk]) {
-        [_callbacks launchFailed:resumeResp.statusMessage];
-        Log(LOG_E, @"Failed Resume Response: %@", resumeResp.statusMessage);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [_callbacks launchFailed:resumeResp.statusMessage];
+            Log(LOG_E, @"Failed Resume Response: %@", resumeResp.statusMessage);
+        });
         return FALSE;
     } else if (resume == NULL || [resume isEqualToString:@"0"]) {
         [_callbacks launchFailed:@"Failed to resume app"];

--- a/Limelight/TemporaryApp.swift
+++ b/Limelight/TemporaryApp.swift
@@ -15,19 +15,23 @@ import Observation
 @objc
 @MainActor
 public class TemporaryApp: NSObject {
-    @objc public var id: String?
-    @objc public var name: String?
+    @objc public var id: String
+    @objc public var name: String
     @objc public var installPath: String?
     @objc public var hdrSupported = false
     @objc public var hidden = false
     @objc public var maybeHost: Any?
 
-    @objc override public init() {}
+    
+    @objc public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
 
     // this is not the right thing to do here
     @objc public init(from app: MoonlightApp, with tempHost: Any) {
-        self.id = app.id
-        self.name = app.name
+        self.id = app.id!
+        self.name = app.name!
         self.hdrSupported = app.hdrSupported
         self.hidden = app.hidden
         self.maybeHost = tempHost

--- a/Limelight/TemporarySettings.swift
+++ b/Limelight/TemporarySettings.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import Observation
+import AppIntents
 
 #if os(visionOS)
 @Observable
@@ -99,7 +100,19 @@ public class TemporarySettings: NSObject {
     case av1
 }
 
-@objc public enum Renderer: UInt8 {
+@objc public enum Renderer: UInt8, Codable, Sendable, AppEnum {
+    
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation {
+            TypeDisplayRepresentation(
+                stringLiteral: "Renderer"
+            )
+        }
+    
+    public static var caseDisplayRepresentations: [Renderer : DisplayRepresentation] = [
+        .classic: .init(stringLiteral: "UIKit (Classic)"),
+        .realitykit: .init(stringLiteral: "RealityKit (Experimental)"),
+    ]
+    
     case classic
     case realitykit
 

--- a/Moonlight Vision/AppIntents/DummyView.swift
+++ b/Moonlight Vision/AppIntents/DummyView.swift
@@ -1,0 +1,28 @@
+//
+//  DumyView.swift
+//  Moonlight
+//
+//  Created by tht7 on 06/02/2025.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+import SwiftUI
+
+struct DummyView: View {
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.dismissWindow) private var dismissWindow
+    @Environment(\.dismiss) private var dismiss
+    
+    @EnvironmentObject private var viewModel: MainViewModel
+    
+    var body: some View {
+        ProgressView()
+            .onContinueUserActivity("dummy") { acc in
+                let config = try! acc.typedPayload(StreamConfiguration.self)
+                print("DUMMY GOT EVENT \(String(describing: config))")
+                //DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                openWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
+                //}
+                dismiss()
+            }
+    }
+}

--- a/Moonlight Vision/AppIntents/MoonlightAppEntity.swift
+++ b/Moonlight Vision/AppIntents/MoonlightAppEntity.swift
@@ -1,0 +1,59 @@
+//
+//  AppEntity.swift
+//  Moonlight
+//
+//  Created by tht7 on 06/02/2025.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.\
+// Ugh Im a little upset by how unoptimized everything in the storage is
+// it's not like CoreData is bad it\s that we dont use any of it's nice (and essential) features >:(
+//
+// Also this file is not optimized at all but it only get's called by the shortcuts app so I don't mind
+
+import Foundation
+import OSLog
+import AppIntents
+
+
+extension TemporaryApp: AppEntity {
+    public typealias DefaultQuery = MoonlightAppQuery
+    
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation = .init(name: "Moonlight Streamable App")
+    
+    public var displayRepresentation: DisplayRepresentation {
+        .init(stringLiteral: self.name)
+    }
+    
+    public static var defaultQuery = MoonlightAppQuery()
+}
+
+@MainActor
+public struct MoonlightAppQuery: EntityQuery {
+    public typealias Entity = TemporaryApp
+    
+    @IntentParameterDependency<OpenMoonlightApp>(
+            \.$host
+        )
+    var intent
+    
+    public init() {}
+    
+    public func entities(for identifiers: [String]) async throws -> [TemporaryApp] {
+        [TemporaryApp](intent?.host.appList ?? [])
+    }
+    
+    public func entities(matching string: String) async throws -> [TemporaryApp] {
+        [TemporaryApp](intent?.host.appList ?? []).filter {
+            $0.name.contains(string)
+        }
+    }
+    
+    public func suggestedEntities() async throws -> [TemporaryApp] {
+        guard let intent = intent else {
+            print("Missing intent")
+            return []
+        }
+        
+        print("Fetching apps for \(String(describing: intent.host.name)) (\(intent.host.appList.count))")
+        return [TemporaryApp](intent.host.appList)
+    }
+}

--- a/Moonlight Vision/AppIntents/MoonlightHostAppEntity.swift
+++ b/Moonlight Vision/AppIntents/MoonlightHostAppEntity.swift
@@ -1,0 +1,48 @@
+//
+//  MoonlightHostAppEntity.swift
+//  Moonlight
+//
+//  Created by tht7 on 06/02/2025.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+import Foundation
+import AppIntents
+
+@MainActor
+extension TemporaryHost: AppEntity {
+    public typealias DefaultQuery = MoonlightHostQuery
+    
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation = .init(name: "Moonlight Streaming Host")
+    
+    public var displayRepresentation: DisplayRepresentation {
+        .init(stringLiteral: self.name)
+    }
+    
+    public static var defaultQuery = MoonlightHostQuery()
+}
+
+@MainActor
+public struct MoonlightHostQuery: EntityStringQuery {
+    public typealias Entity = TemporaryHost
+    
+    public init() {}
+    
+    @MainActor
+    public func entities(for identifiers: [String]) async throws -> [TemporaryHost] {
+        return DataManager().getHosts().filter {
+            if identifiers.contains($0.id) {
+                print("FOR QUERY \(identifiers) FOUND HOST \(String(describing: $0))")
+            }
+            return identifiers.contains($0.id)
+        }
+    }
+    
+    public func entities(matching string: String) async throws -> [TemporaryHost] {
+        return DataManager().getHosts().filter { $0.name.contains(string) }
+    }
+    
+    public func suggestedEntities() async throws -> [TemporaryHost] {
+        return DataManager().getHosts()
+    }
+}
+

--- a/Moonlight Vision/AppIntents/OpenStreamAppIntent.swift
+++ b/Moonlight Vision/AppIntents/OpenStreamAppIntent.swift
@@ -1,0 +1,53 @@
+//
+//  OpenStreamAppIntent.swift
+//  Moonlight
+//
+//  Created by tht7 on 06/02/2025.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+import AppIntents
+
+@MainActor
+struct OpenMoonlightApp: AppIntent {
+    
+    public static var openAppWhenRun: Bool = true
+    
+    @Parameter(title: "Host")
+    var host: TemporaryHost
+    
+    @Parameter(title: "Steamed App")
+    var app: TemporaryApp
+    
+    @Parameter(title: "Renderer")
+    var renderer: Renderer
+
+    static var title: LocalizedStringResource = "Start streaming app"
+
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        app.setHost(host)
+        let config = MainViewModel.shared.stream(app: app)
+        let activity = NSUserActivity(activityType: "dummy")
+//        activity.userInfo = ["some key": config!]
+        activity.targetContentIdentifier = "dummy" // IMPORTANT
+        try! activity.setTypedPayload(config!)
+        MainViewModel.shared.streamSettings.renderer = self.renderer
+        UIApplication.shared.requestSceneSessionActivation(nil, userActivity: activity, options: nil)
+        print("perform intent")
+        return .result()
+    }
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Stream from \(\.$host), stream app \(\.$app) with renderer \(\.$renderer)")
+    }
+  
+    init() {
+        self.renderer = MainViewModel.shared.streamSettings.renderer
+    }
+
+    init(app: TemporaryApp) {
+        self.renderer = MainViewModel.shared.streamSettings.renderer
+        self.app = app
+    }
+}

--- a/Moonlight Vision/AppsView.swift
+++ b/Moonlight Vision/AppsView.swift
@@ -16,25 +16,31 @@ struct AppsView: View {
     @Environment(\.dismissWindow) private var dismissWindow
     @Environment(\.openImmersiveSpace) private var openImmersiveSpace
     
+    @State private var nowLoading: String?
+    
     @Binding
     public var host: TemporaryHost
     
     var body: some View {
         List {
             ForEach(host.appList.sorted(by: { $0.name ?? "" < $1.name ?? "" }), id: \.id) { app in
-                AppButtonView(host: host, app: app) {
-                    if let config = viewModel.stream(app: app) {
-                        if (viewModel.streamSettings.renderer == .realitykit) {
-                            openWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
-                            dismissWindow(id: "mainView")
-//                            Task {
-                                
-                                
-                                //                                await openImmersiveSpace(id: "immesiveSpace", value: config)
-                                
-//                            }
-                        } else {
-                            pushWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
+                HStack {
+                    if (nowLoading == (app.id ?? app.name)) {
+                        ProgressView()
+                    }
+                    AppButtonView(host: host, app: app) {
+                        if (nowLoading != nil) {
+                            return
+                        }
+                        nowLoading = app.id ?? app.name
+                        if let config = viewModel.stream(app: app) {
+                            if (viewModel.streamSettings.renderer == .realitykit) {
+                                openWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
+                                dismissWindow(id: "mainView")
+                            } else {
+                                pushWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
+                                nowLoading = nil
+                            }
                         }
                     }
                 }
@@ -44,18 +50,20 @@ struct AppsView: View {
         .onAppear() {
             // this MUST be async lmao
             Task {
+                print("LOAD")
                 viewModel.refreshAppsFor(host: host)
             }
         }.refreshable() {
+            print("REFRESH")
             viewModel.refreshAppsFor(host: host)
         }
     }
 }
 
 struct AppButtonView: View {
-    var host: TemporaryHost
-    var app: TemporaryApp
-    var action: () -> Void
+    let host: TemporaryHost
+    let app: TemporaryApp
+    let action: () -> Void
     
     var body: some View {
         Button(app.name ?? "Unknown", action: action)

--- a/Moonlight Vision/MainContentView.swift
+++ b/Moonlight Vision/MainContentView.swift
@@ -18,7 +18,6 @@ struct MainContentView: View {
     @State private var isDeletingHost = false
     @State private var hostToDelete: TemporaryHost?
     @State private var newHostIp = ""
-    @State private var dimPassthrough = true
     @State private var isRefreshingDiscovery = false // State to track refresh status
 
 
@@ -119,6 +118,15 @@ struct MainContentView: View {
                     name: UIApplication.didBecomeActiveNotification,
                     object: nil
                 )
+                // If we have some hosts in the host list and no host has been selected
+                // try to select the first paired host automatically.
+                // this will usually happen when we close the stream and reopen this window
+                // when we do, the host list won't change but we still want to keep the list looking nice and select something by default
+                if selectedHost == nil,
+                   let firstHost = viewModel.hosts.first(where: { $0.pairState == .paired })
+                {
+                    selectedHost = firstHost
+                }
                 //if !isRefreshingDiscovery { // Only begin refresh if not already toggled on
                 //    viewModel.beginRefresh()
                 //}

--- a/Moonlight Vision/MainViewModel.swift
+++ b/Moonlight Vision/MainViewModel.swift
@@ -13,6 +13,9 @@ import AVFoundation
 
 @MainActor
 class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback, AppAssetCallback {
+    @objc
+    static let shared = MainViewModel()
+    
     @Published var hosts: [TemporaryHost] = []
 
     @Published var pairingInProgress = false
@@ -42,6 +45,7 @@ class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback
     private var currentlyPairingHost: TemporaryHost?
 
     override init() {
+        print("INITING MAIN MODEL")
         boxArtCache = NSCache<TemporaryApp, UIImage>()
         dataManager = DataManager()
         // should this be in viewDidLoad and not init?
@@ -450,7 +454,7 @@ class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback
             return nil
         }
 
-        config.host = host.activeAddress
+        config.host = host.activeAddress ?? host.address
         config.httpsPort = host.httpsPort
         config.appID = app.id
         config.appName = app.name
@@ -473,7 +477,7 @@ class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback
         config.useFramePacing = streamSettings.useFramePacing
         config.swapABXYButtons = streamSettings.swapABXYButtons
         config.multiController = streamSettings.multiController
-        config.gamepadMask = ControllerSupport.getConnectedGamepadMask(config)
+        config.gamepadMask = ControllerSupport.getConnectedGamepadMask(config, settings: streamSettings)
 
         // 7.1, always
         config.audioConfiguration = (0x63f << 16) | (8 << 8) | 0xca

--- a/Moonlight Vision/MoonlightVisionApp.swift
+++ b/Moonlight Vision/MoonlightVisionApp.swift
@@ -22,36 +22,22 @@ struct MoonlightVisionApp: SwiftUI.App {
         .windowStyle(.plain)
         .windowResizability(.contentSize)
         
+        WindowGroup("LoadingStream", id: "dummy") {
+            DummyView()
+                .environmentObject(appDelegate.mainViewModel)
+        }
+        .handlesExternalEvents(matching: ["dummy"])
+        
         WindowGroup(id: "realitykitStreamingWindow", for: StreamConfiguration.self) { streamConfig in
-            @State var lol: Bool = false
-            if streamConfig.wrappedValue != nil {
-                RealityKitStreamView(streamConfig: Binding(
-                    get: { streamConfig.wrappedValue! },
-                    set: { n in streamConfig.wrappedValue = n }
-                ))
+                RealityKitStreamView(streamConfig: streamConfig)
+                .environmentObject(appDelegate.mainViewModel)
                 .onDisappear {
-                    //print("SteamWindowClosedOutside")
+                    streamConfig.wrappedValue = nil
                 }
-                    .environmentObject(appDelegate.mainViewModel)
-                    .onChange(of: appDelegate.mainViewModel) {
-                        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-                                                let geometryRequest = UIWindowScene.GeometryPreferences.Vision(resizingRestrictions: .uniform)
-                                                windowScene.requestGeometryUpdate(geometryRequest)
-                    }
-//                    .onAppear {
-//                        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
-//                        let geometryRequest = UIWindowScene.GeometryPreferences.Vision(resizingRestrictions: .uniform)
-//                        windowScene.requestGeometryUpdate(geometryRequest)
-//                    }
-                   
-            } else {
-                Text("No computer selected")
-            }
         }
         .windowStyle(.volumetric)
         .defaultSize(width: 2, height: 2, depth: 2, in: .meters)
-//        .windowResizability(.contentSize)
-        
+
         WindowGroup(id: "classicStreamingWindow", for: StreamConfiguration.self) { streamConfig in
             if streamConfig.wrappedValue != nil {
                 UIKitStreamView(streamConfig: Binding(

--- a/Moonlight Vision/ObservableConnectionManager.swift
+++ b/Moonlight Vision/ObservableConnectionManager.swift
@@ -57,6 +57,7 @@ import Combine
     func launchFailed(_ message: String!) {
         print("Launch failed: \(message ?? "Unknown error")")
         errorMessage = message
+        showAlert = true
     }
     
     func rumble(_ controllerNumber: UInt16, lowFreqMotor: UInt16, highFreqMotor: UInt16) {

--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -28,6 +28,26 @@ class DummyControllerDelegate: NSObject, ControllerSupportDelegate {
 }
 
 struct RealityKitStreamView: View {
+    @Environment(\.dismissWindow) private var dismissWindow
+    @Binding var streamConfig: StreamConfiguration?
+    
+    
+    var body: some View {
+        if streamConfig != nil {
+            _RealityKitStreamView(streamConfig: Binding<StreamConfiguration>(
+                get: { streamConfig ?? StreamConfiguration() },
+                set: { streamConfig = $0 }
+            )) {
+                dismissWindow()
+                streamConfig = nil
+            }
+        } else {
+            ProgressView().onAppear { dismissWindow() }
+        }
+    }
+}
+
+struct _RealityKitStreamView: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
     @Environment(\.dismiss) private var dismiss
@@ -58,8 +78,11 @@ struct RealityKitStreamView: View {
 
     @State var texture: TextureResource
     @State var screen: ModelEntity = ModelEntity()
+    
+    let closeAction: () -> Void
 
-    init(streamConfig: Binding<StreamConfiguration>) {
+    init(streamConfig: Binding<StreamConfiguration>, closeAction: @escaping () -> Void) {
+        self.closeAction = closeAction
         self._streamConfig = streamConfig
         self.controllerSupport = ControllerSupport(config: streamConfig.wrappedValue, delegate: DummyControllerDelegate())
         let data = Data.init(count: 4 * Int(streamConfig.wrappedValue.width) * Int(streamConfig.wrappedValue.height)) // Dummy data
@@ -77,7 +100,7 @@ struct RealityKitStreamView: View {
     var body: some View {
         GeometryReader3D { proxy in
                 RealityView { content in
-                    let mesh = try! RealityKitStreamView.generateCurvedPlane(width: MAX_WIDTH_METERS, aspectRatio: aspectRatio, resulotion: (50,50), curveMagnitude: viewModel.streamSettings.realitykitRendererCurvature * curveAnimationMultiplier)
+                    let mesh = try! _RealityKitStreamView.generateCurvedPlane(width: MAX_WIDTH_METERS, aspectRatio: aspectRatio, resulotion: (50,50), curveMagnitude: viewModel.streamSettings.realitykitRendererCurvature * curveAnimationMultiplier)
                     let colBox = ShapeResource.generateBox(width: 2, height: 2 * aspectRatio, depth: 0.001).offsetBy(translation: .init(x: 0, y: -0.43, z: 1))
                     screen = ModelEntity(mesh: mesh, materials: [UnlitMaterial(texture: self.texture)])
                     screen.collision = CollisionComponent(shapes: [
@@ -86,7 +109,7 @@ struct RealityKitStreamView: View {
                     screen.components.set(InputTargetComponent())
                     content.add(screen)
                 } update: { content in
-                    let mesh = try! RealityKitStreamView.generateCurvedPlane(width: MAX_WIDTH_METERS, aspectRatio: aspectRatio, resulotion: (50,50), curveMagnitude: viewModel.streamSettings.realitykitRendererCurvature * curveAnimationMultiplier)
+                    let mesh = try! _RealityKitStreamView.generateCurvedPlane(width: MAX_WIDTH_METERS, aspectRatio: aspectRatio, resulotion: (50,50), curveMagnitude: viewModel.streamSettings.realitykitRendererCurvature * curveAnimationMultiplier)
                     let size = content.convert(proxy.frame(in: .local), from: .local, to: .scene)
                     screen.transform.scale = .init(repeating: size.extents.x / 2)
                     screen.transform.translation.y = height
@@ -168,6 +191,8 @@ struct RealityKitStreamView: View {
         }
         .onAppear() {
             dismissWindow(id: "mainView")
+            dismissWindow(id: "dummy")
+//            dismissWindow(id: "realitykitStreamingWindow")
             self.curveAnimationMultiplier = viewModel.streamSettings.realitykitRendererAnimateOpening ? 0 : 1
             self._streamMan = StreamManager(
                 config:self.streamConfig,
@@ -205,12 +230,14 @@ struct RealityKitStreamView: View {
                 break
             case .background:
                 print("background")
-                dismissWindow()
                 viewModel.activelyStreaming = false
                 _streamMan?.stopStream()
                 _streamMan = nil
                 controllerSupport?.cleanup()
+//                streamConfig = nil
                 if !shouldClose { openWindow(id: "mainView") }
+                self.closeAction()
+//                dismissWindow()
             @unknown default: break
                 //print("unknown default")
             }
@@ -290,3 +317,4 @@ struct RealityKitStreamView: View {
 ////    NativeStreamView()
 //    NativeStreamView()
 //}
+

--- a/Moonlight iOS/AppDelegate.m
+++ b/Moonlight iOS/AppDelegate.m
@@ -94,11 +94,7 @@ static NSString* DB_NAME = @"Limelight_iOS.sqlite";
 #pragma mark - MainViewModel
 
 - (MainViewModel *)mainViewModel {
-    if (_mainViewModel != nil) {
-        return _mainViewModel;
-    }
-    _mainViewModel = [[MainViewModel alloc] init];
-    return _mainViewModel;
+    return [MainViewModel shared];
 }
 
 #pragma mark - Core Data stack

--- a/Moonlight iOS/ViewControllers/MainFrameViewController.m
+++ b/Moonlight iOS/ViewControllers/MainFrameViewController.m
@@ -641,7 +641,7 @@ static NSMutableSet* hostList;
     
     // multiController must be set before calling getConnectedGamepadMask
     _streamConfig.multiController = streamSettings.multiController;
-    _streamConfig.gamepadMask = [ControllerSupport getConnectedGamepadMask:_streamConfig];
+    _streamConfig.gamepadMask = [ControllerSupport getConnectedGamepadMask:_streamConfig settings: streamSettings];
     
     // Probe for supported channel configurations
     int physicalOutputChannels = (int)[AVAudioSession sharedInstance].maximumOutputNumberOfChannels;

--- a/Moonlight iOS/ViewControllers/StreamFrameViewController.m
+++ b/Moonlight iOS/ViewControllers/StreamFrameViewController.m
@@ -535,8 +535,7 @@
 
 - (void) launchFailed:(NSString*)message {
     Log(LOG_I, @"Launch failed: %@", message);
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
+
         // Allow the display to go to sleep now
         [UIApplication sharedApplication].idleTimerDisabled = NO;
         
@@ -548,7 +547,6 @@
             [self returnToMainFrame];
         }]];
         [self presentViewController:alert animated:YES completion:nil];
-    });
 }
 
 - (void)rumble:(unsigned short)controllerNumber lowFreqMotor:(unsigned short)lowFreqMotor highFreqMotor:(unsigned short)highFreqMotor {

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -531,6 +531,10 @@
 		FBDE86E519F82297001C18A8 /* UIAppView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIAppView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		B10D61AE2D54D0F600550218 /* AppIntents */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = AppIntents; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		F7A1193D2B5DDF73001E8686 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -639,6 +643,7 @@
 		F7A119592B5DE1AB001E8686 /* Moonlight Vision */ = {
 			isa = PBXGroup;
 			children = (
+				B10D61AE2D54D0F600550218 /* AppIntents */,
 				E77582CC2D53F3E500948545 /* Shaders.metal */,
 				3E86FC1C2D4FFDED0016BB8E /* UpdatesView.swift */,
 				E77582CE2D54020300948545 /* CVMetalHelpers.swift */,
@@ -1092,6 +1097,9 @@
 			);
 			dependencies = (
 				F7A119092B5DDF73001E8686 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				B10D61AE2D54D0F600550218 /* AppIntents */,
 			);
 			name = "Moonlight XrOS";
 			packageProductDependencies = (


### PR DESCRIPTION
* Fixed updating UI values from background thread
* Fixed not showing error messages in RealityKit when we fail to launch
* Made sure the Controller support can init and check it's settings without having to fetch them again from the database (which fixes the slow start button when selecting a stream)
* Made sure to avoid "CoreData Faults" we can afford to fetch all the data in one big bulk, and it (mostly) fixes accessing data from backgound threads
* Added a new DummyView, that view will react to UserActivities and open the appropriate stream, making sure to skip most of the overhead in the main view
* Made sure there's a computer selected in the Main view when coming back from RealityKit, makes it a little nicer
* Made the MainViewModel a singleton which will allow it to be access in the background and without the involvement of the AppDelegate
* Did some minor cleaning
* Made sure TemporaryApp has some minimum construction requirements, and also made it Identifiable 
* Added a new AppIntent! to allow users to open a stream with shortcuts! that will avoid the main view and most of the overhead that comes with it and immediately open the StreamView, the idea here is that users will be able to add "Steam Big Picture" (or whatever apps they have defined) directly to their home screen, giving the new illusion of native-ness