### PR TITLE
Audio and RealityKit QoL improvements

### DIFF
--- a/Limelight/Stream/Connection.m
+++ b/Limelight/Stream/Connection.m
@@ -244,8 +244,15 @@ int ArInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, v
     // Start playback
     SDL_PauseAudioDevice(audioDevice, 0);
     
+#ifdef TARGET_OS_VISION
+    // Force direct stereo and voice chat microphone by default
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+    [[AVAudioSession sharedInstance] setMode:AVAudioSessionModeVoiceChat error:nil];
+    [[AVAudioSession sharedInstance] setIntendedSpatialExperience:AVAudioSessionSpatialExperienceBypassed options:@{} error:nil];
+#else
     // Disable lowering volume of other audio streams (SDL sets AVAudioSessionCategoryOptionDuckOthers by default)
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+#endif
     
     return 0;
 }

--- a/Moonlight Vision/AudioHelpers.swift
+++ b/Moonlight Vision/AudioHelpers.swift
@@ -1,0 +1,83 @@
+//
+//  AudioHelpers.swift
+//  Moonlight
+//
+//  Created by Max Thomas on 2/6/25.
+//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
+//
+
+class AudioHelpers {
+
+    private static func fixCategoryAndMic() {
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setActive(true)
+            try audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .allowBluetoothA2DP, .allowAirPlay])
+            try audioSession.setMode(.voiceChat)
+            try audioSession.setPreferredInputNumberOfChannels(1)
+        }
+        catch {
+            print("Failed to set the audio session mic/category configuration?")
+        }
+    }
+
+    /// Ensure that the audio session is direct stereo
+    /// Also ensures that the microphone uses voice chat noise cancellation.
+    static func fixAudioForDirectStereo() {
+        print("AudioHelpers - Fix for direct stereo")
+        AudioHelpers.fixCategoryAndMic()
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setPreferredOutputNumberOfChannels(2)
+            try audioSession.setIntendedSpatialExperience(.bypassed)
+        } catch {
+            print("Failed to set the audio session configuration?")
+        }
+    }
+    
+    /// Ensure that the audio session is surround and anchored to the active window
+    /// Also ensures that the microphone uses voice chat noise cancellation.
+    static func fixAudioForSurroundForCurrentWindow() {
+        AudioHelpers.fixCategoryAndMic()
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            if let id = UIApplication.shared.connectedScenes.first?.session.persistentIdentifier {
+                print("AudioHelpers - Found current window \(id)")
+
+                // TODO(shinyquagsire23): Not sure how this would interact w/ surround sound or Dolby
+                try audioSession.setPreferredOutputNumberOfChannels(audioSession.maximumOutputNumberOfChannels)
+                try audioSession.setIntendedSpatialExperience(.headTracked(soundStageSize: .medium, anchoringStrategy: .scene(identifier: id)))
+            }
+            else {
+                print("AudioHelpers - Couldn't find current window?")
+                fixAudioForDirectStereo()
+            }
+        } catch {
+            print("Failed to set the audio session configuration?")
+        }
+    }
+    
+    static func fixAudioForSurroundForUIKitWindow(_ window: UIWindow) {
+        AudioHelpers.fixCategoryAndMic()
+        
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            print(window, window.windowScene?.session.persistentIdentifier)
+            if let id = window.windowScene?.session.persistentIdentifier {
+                print("AudioHelpers - Found UIKit window \(id)")
+                
+                // TODO(shinyquagsire23): Not sure how this would interact w/ surround sound or Dolby
+                try audioSession.setPreferredOutputNumberOfChannels(audioSession.maximumOutputNumberOfChannels)
+                try audioSession.setIntendedSpatialExperience(.headTracked(soundStageSize: .medium, anchoringStrategy: .scene(identifier: id)))
+            }
+            else {
+                fixAudioForDirectStereo()
+            }
+        } catch {
+            print("AudioHelpers - Couldn't find UIKit window?")
+            print("Failed to set the audio session configuration?")
+        }
+    }
+}

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -393,6 +393,7 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
                     attributes[kCVPixelBufferPixelFormatTypeKey] = decodingFormat
                 }
                 VTDecompressionSessionCreate(allocator: kCFAllocatorDefault, formatDescription: formatDesc, decoderSpecification: videoDecoderSpecification as CFDictionary, imageBufferAttributes: attributes as CFDictionary, outputCallback: &self.decoderCallback, decompressionSessionOut: &self.session)
+                AudioHelpers.fixAudioForSurroundForCurrentWindow() // TODO(shinyquagsire23): Make this configurable?
             } else {
                 // Couldn’t create format description yet
 //                free(dataPtr)

--- a/Moonlight Vision/MoonlightVisionApp.swift
+++ b/Moonlight Vision/MoonlightVisionApp.swift
@@ -37,6 +37,10 @@ struct MoonlightVisionApp: SwiftUI.App {
                         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
                                                 let geometryRequest = UIWindowScene.GeometryPreferences.Vision(resizingRestrictions: .uniform)
                                                 windowScene.requestGeometryUpdate(geometryRequest)
+
+                        // Change audio center to this window
+                        // TODO(shinyquagsire23): Maybe this should be configurable?
+                        AudioHelpers.fixAudioForSurroundForCurrentWindow()
                     }
 //                    .onAppear {
 //                        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }

--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -217,7 +217,8 @@ struct RealityKitStreamView: View {
         }
         .persistentSystemOverlays(viewModel.streamSettings.dimPassthrough ? .hidden : .automatic)
         .preferredSurroundingsEffect(viewModel.streamSettings.dimPassthrough ? .systemDark : nil)
-
+        .volumeBaseplateVisibility(viewModel.streamSettings.dimPassthrough ? .hidden : .automatic)
+        .supportedVolumeViewpoints(.front)
     }
 
     func animateOpening() {

--- a/Moonlight Vision/UIKitStreamView.swift
+++ b/Moonlight Vision/UIKitStreamView.swift
@@ -30,6 +30,7 @@ struct _UIKitStreamViewWindowButton: View {
         Button {
             if let window = currentWindow {
                 applyAspectRatioLock(streamConfig: streamConfig, targetWindow: window) // Pass the window
+                AudioHelpers.fixAudioForSurroundForUIKitWindow(window) // TODO(shinyquagsire23): Make this configurable
             } else {
                 print("Error: No window reference available to apply aspect ratio lock.")
                 // Optionally provide user feedback here, e.g., an alert
@@ -72,6 +73,7 @@ struct _UIKitStreamViewWindowButton: View {
                     if let window = viewToFindWindow?.window {
                         print("Found window by traversing view hierarchy: \(window)")
                         currentWindow = window
+                        AudioHelpers.fixAudioForSurroundForUIKitWindow(window)
                         return
                     }
                     viewToFindWindow = viewToFindWindow?.superview
@@ -104,6 +106,13 @@ struct _UIKitStreamView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewControllerType {
         let streamView = StreamFrameViewController()
         streamView.streamConfig = streamConfig
+        streamView.connectedCallback = {
+            print("Connected in Swift!")
+            AudioHelpers.fixAudioForSurroundForCurrentWindow() // TODO(shinyquagsire23): Make this configurable
+        };
+        streamView.disconnectedCallback = {
+            print("Disconnected in Swift!")
+        };
         _UIKitStreamView.controllerReference.object = streamView // Use the static reference
         return streamView
     }

--- a/Moonlight iOS/ViewControllers/StreamFrameViewController.h
+++ b/Moonlight iOS/ViewControllers/StreamFrameViewController.h
@@ -20,5 +20,9 @@
 #endif
 @property (nonatomic, strong) StreamConfiguration* streamConfig;
 
+typedef void (^noargCallbackType)(void);
+@property (nonatomic, strong) noargCallbackType connectedCallback;
+@property (nonatomic, strong) noargCallbackType disconnectedCallback;
+
 -(void)updatePreferredDisplayMode:(BOOL)streamActive;
 @end

--- a/Moonlight iOS/ViewControllers/StreamFrameViewController.m
+++ b/Moonlight iOS/ViewControllers/StreamFrameViewController.m
@@ -403,6 +403,10 @@
                                                                      userInfo:nil
                                                                       repeats:YES];
         }
+        
+        if (self->_connectedCallback) {
+            self->_connectedCallback();
+        }
     });
 }
 
@@ -482,6 +486,10 @@
             [self returnToMainFrame];
         }]];
         [self presentViewController:conTermAlert animated:YES completion:nil];
+        
+        if (self->_disconnectedCallback) {
+            self->_disconnectedCallback();
+        }
     });
 
     [_streamMan stopStream];

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		DC1F5A07206436B20037755F /* ConnectionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1F5A06206436B20037755F /* ConnectionHelper.m */; };
 		E77582CD2D53F3EB00948545 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E77582CC2D53F3E500948545 /* Shaders.metal */; };
 		E77582CF2D54020700948545 /* CVMetalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77582CE2D54020300948545 /* CVMetalHelpers.swift */; };
+		E77582EB2D5550D500948545 /* AudioHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77582EA2D5550D200948545 /* AudioHelpers.swift */; };
 		F71801422B65483D00A9336B /* AppsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71801412B65483D00A9336B /* AppsView.swift */; };
 		F71801442B654D9100A9336B /* TemporaryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71801432B654D9100A9336B /* TemporaryApp.swift */; };
 		F71801452B65583700A9336B /* TemporaryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71801432B654D9100A9336B /* TemporaryApp.swift */; };
@@ -331,6 +332,7 @@
 		DC1F5A06206436B20037755F /* ConnectionHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConnectionHelper.m; sourceTree = "<group>"; };
 		E77582CC2D53F3E500948545 /* Shaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
 		E77582CE2D54020300948545 /* CVMetalHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CVMetalHelpers.swift; sourceTree = "<group>"; };
+		E77582EA2D5550D200948545 /* AudioHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioHelpers.swift; sourceTree = "<group>"; };
 		F71801412B65483D00A9336B /* AppsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppsView.swift; sourceTree = "<group>"; };
 		F71801432B654D9100A9336B /* TemporaryApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryApp.swift; sourceTree = "<group>"; };
 		F71801492B655C1F00A9336B /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 			children = (
 				E77582CC2D53F3E500948545 /* Shaders.metal */,
 				3E86FC1C2D4FFDED0016BB8E /* UpdatesView.swift */,
+				E77582EA2D5550D200948545 /* AudioHelpers.swift */,
 				E77582CE2D54020300948545 /* CVMetalHelpers.swift */,
 				B1EDB1302D4D95A700EB1839 /* DrawableVideoDecoder.swift */,
 				B1EDB1312D4D95A700EB1839 /* ObservableConnectionManager.swift */,
@@ -1265,6 +1268,7 @@
 				F7A119122B5DDF73001E8686 /* AppListResponse.m in Sources */,
 				F7A119132B5DDF73001E8686 /* Utils.m in Sources */,
 				F7A119152B5DDF73001E8686 /* Connection.m in Sources */,
+				E77582EB2D5550D500948545 /* AudioHelpers.swift in Sources */,
 				F7A119162B5DDF73001E8686 /* AppAssetRetriever.m in Sources */,
 				F7A119172B5DDF73001E8686 /* WakeOnLanManager.m in Sources */,
 				B1EDB1352D4D95A700EB1839 /* StreamControls.swift in Sources */,


### PR DESCRIPTION
 - Fix the ornaments hiding themselves on the other side of the volume sometimes by limiting `supportedVolumeViewpoints` to `.front`
 - Set `volumeBaseplateVisibility` to `.hidden` when dimmed (might be worth DIYing some resize corner indicators at some point since that's all I ever use the baseplate for is to find the corners)
 - Fix audio session to be tracked to the current window instead of getting stuck in weird positions
   - TODO (later), maybe allow configuring direct audio, for games that are extremely binaural instead of front stereo/surround.