### PR TITLE
Add support for full-width 3D SBS display

### DIFF
--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -62,9 +62,20 @@ struct _RealityKitStreamView: View {
     
     @State var shouldClose: Bool = false
 
-    var aspectRatio: Float {
-        Float(streamConfig.height) / Float(streamConfig.width)
+
+    var isSBSVideo: Bool {
+        let ratio = Float(streamConfig.width) / Float(streamConfig.height)
+        return abs(ratio - (32.0 / 9.0)) < 0.01 
     }
+
+    var aspectRatio: Float {
+        if videoMode == .sideBySide3D && isSBSVideo {
+            return Float(streamConfig.height) / Float(streamConfig.width / 2)
+        } else {
+            return Float(streamConfig.height) / Float(streamConfig.width)
+        }
+    }
+    
 
     @State var animationTimer: Timer?
 


### PR DESCRIPTION
When 3D SBS is enabled, if a 32:9 aspect ratio is detected, the display will automatically adjust to 16:9 to produce a correct full-width image,Maintain half-width for other aspect ratios.

https://github.com/user-attachments/assets/802fa5d0-3085-42f4-ac8e-1d94ce4b7760

