### PR TITLE
Fixed black screen recovery issues and technical improvements, and added some new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,153 @@
+# Changelog - Moonlight Vision Pro Improvements
+
+# 更新日志 - Moonlight Vision Pro 改进
+
+## Bug Fixes / 错误修复
+
+### Fixed Black Screen Recovery Issue / 修复黑屏恢复问题
+- **RealityKit Mode**: Fixed stream window turning black after returning from background or immersive scenes. Stream now properly resumes when the window becomes active again.
+- **UIKit Mode**: Applied the same black screen recovery fix to UIKit streaming mode. Stream properly resumes after backgrounding or closing/reopening the app.
+- **RealityKit 模式**: 修复了从后台或沉浸式场景返回后串流窗口变黑的问题。窗口重新激活时串流现在可以正常恢复。
+- **UIKit 模式**: 将相同的黑屏恢复修复应用到 UIKit 串流模式。后台运行或关闭/重新打开应用后串流可以正常恢复。
+
+### Fixed Window Lifecycle Management / 修复窗口生命周期管理
+- **Home Button Handling**: Fixed crashes and orphaned windows when pressing the Home button during streaming. Windows now properly pause the stream instead of crashing.
+- **Window Dismissal**: Improved window dismissal logic to prevent residual window bars and unresponsive states. Implemented user-driven manual window closure with clear instructions.
+- **Background/Resume**: Properly handle app backgrounding and resumption. Streams pause when backgrounded and resume when the app becomes active again.
+- **Home 按钮处理**: 修复了串流期间按下 Home 按钮时的崩溃和残留窗口问题。窗口现在会正确暂停串流而不是崩溃。
+- **窗口关闭**: 改进了窗口关闭逻辑，防止残留窗口横条和无响应状态。实现了用户驱动的窗口手动关闭，并提供清晰的说明。
+- **后台/恢复**: 正确处理应用后台化和恢复。应用进入后台时串流暂停，应用重新激活时恢复。
+
+### Fixed Stream Conflict Handling / 修复串流冲突处理
+- **Duplicate Stream Prevention**: Added detection for active stream windows. When attempting to start a new stream while an old one is still open, users are prompted with options: return to existing window, force quit old stream, or cancel.
+- **Manual Window Closure**: Old stream windows display a clear message asking users to manually close them before starting a new stream. This prevents multiple stream windows and app crashes.
+- **状态检测**: 添加了活动串流窗口的检测。当尝试启动新串流而旧窗口仍打开时，用户会收到提示：返回现有窗口、强制结束旧串流或取消。
+- **手动窗口关闭**: 旧串流窗口显示清晰消息，要求用户手动关闭后再启动新串流。这防止了多个串流窗口和应用崩溃。
+
+## New Features / 新功能
+
+### Audio Session Management / 音频会话管理
+- **Three Audio Modes**: Added three configurable audio session modes in Settings:
+  - **Microphone Exclusive (Default)**: Traditional exclusive audio session that mutes other system media
+  - **Allow Mixing with Other Audio**: Allows Moonlight audio to mix with other apps' audio
+  - **Exclusive Only When Microphone Active**: Only uses exclusive mode when microphone is active, allowing mixing otherwise
+- **三种音频模式**: 在设置中添加了三种可配置的音频会话模式：
+  - **麦克风独占（默认）**: 传统的独占音频会话，会静音其他系统媒体
+  - **允许与其他音频混音**: 允许 Moonlight 音频与其他应用的音频混音
+  - **仅在使用麦克风时才切换到独占模式**: 仅在麦克风激活时使用独占模式，其他时候允许混音
+
+### Window Corner Radius Customization / 窗口圆角自定义
+- Added a slider in Settings to adjust the corner radius of streaming windows (both UIKit and RealityKit modes)
+- Range: 0-60 pixels, default: 0 pixels (for maximum clarity)
+- Changes apply immediately to active streams
+- **Note**: Corner radius may slightly affect rendering sharpness. Default is set to 0 for maximum clarity.
+- **窗口圆角调整**: 在设置中添加了滑块来调整串流窗口的圆角（UIKit 和 RealityKit 模式均支持）
+- **范围**: 0-60 像素，默认：0 像素（以获得最佳清晰度）
+- **即时生效**: 更改会立即应用到活动串流
+- **注意**: 圆角可能会略微影响渲染清晰度。默认设置为 0 以获得最佳清晰度。
+
+### Language Selection / 语言选择
+- **First Launch Prompt**: Added a language selection prompt on first app launch, allowing users to choose between English and Simplified Chinese
+- **Settings Integration**: Added language picker in Settings menu for changing language at any time
+- **Persistent Storage**: Language preference is saved and persists across app restarts
+- **首次启动提示**: 在首次启动应用时添加了语言选择提示，允许用户在英文和简体中文之间选择
+- **设置集成**: 在设置菜单中添加了语言选择器，可随时更改语言
+- **持久化存储**: 语言偏好设置会被保存，并在应用重启后保持
+
+### Comprehensive Localization / 全面本地化
+- **Complete UI Translation**: All user-facing text in the app now supports both English and Simplified Chinese:
+  - Main menu and navigation
+  - Settings and preferences
+  - Error messages and alerts
+  - Stream controls and status messages
+  - Pairing and connection prompts
+  - Window close instructions
+- **Dynamic Language Switching**: Language changes take effect immediately without requiring app restart
+- **完整界面翻译**: 应用中所有面向用户的文本现在都支持英文和简体中文：
+  - 主菜单和导航
+  - 设置和偏好
+  - 错误消息和提示
+  - 串流控制和状态消息
+  - 配对和连接提示
+  - 窗口关闭说明
+- **动态语言切换**: 语言更改立即生效，无需重启应用
+
+### Aspect Ratio Lock / 宽高比锁定
+- **UIKit Mode**: Automatically applies aspect ratio lock when stream starts, eliminating the need for manual button presses to avoid black bars when resizing windows
+- **UIKit 模式**: 串流启动时自动应用宽高比锁定，无需手动按按钮即可避免调整窗口大小时出现黑边
+
+## Technical Improvements / 技术改进
+
+### Code Organization / 代码组织
+- Refactored stream lifecycle management into separate methods for better maintainability
+- Improved state management with proper `@State` and `@Published` properties
+- Added helper methods for audio session configuration and language localization
+- **代码重构**: 将串流生命周期管理重构为独立方法，提高可维护性
+- **状态管理**: 使用适当的 `@State` 和 `@Published` 属性改进状态管理
+- **辅助方法**: 添加了音频会话配置和语言本地化的辅助方法
+
+### Error Handling / 错误处理
+- Improved error messages with localized text
+- Better handling of edge cases in window lifecycle
+- More robust stream state management
+- **错误处理改进**: 使用本地化文本改进错误消息
+- **边缘情况处理**: 更好地处理窗口生命周期中的边缘情况
+- **状态管理**: 更健壮的串流状态管理
+
+## Files Modified / 修改的文件
+
+### Swift Files / Swift 文件
+- `Moonlight Vision/MainViewModel.swift` - Added language management, audio session helpers, stream conflict detection
+- `Moonlight Vision/MainContentView.swift` - Added language prompt, improved window dismissal logic
+- `Moonlight Vision/RealityKitStreamView.swift` - Fixed black screen recovery, added manual close prompt, corner radius support
+- `Moonlight Vision/UIKitStreamView.swift` - Fixed black screen recovery, added aspect ratio auto-lock, manual close prompt
+- `Moonlight Vision/AppsView.swift` - Added stream conflict detection and alerts
+- `Moonlight Vision/SettingsView.swift` - Added audio session mode picker, corner radius slider, language picker
+- `Moonlight Vision/ComputerView.swift` - Localized all user-facing text
+- `Moonlight Vision/StreamControls.swift` - Localized control buttons
+- `Moonlight Vision/UpdatesView.swift` - Localized section headers
+- `Moonlight Vision/LanguagePromptView.swift` - New file for first-launch language selection
+- `Limelight/TemporarySettings.swift` - Added audio session mode enum, window corner radius, app language settings
+
+### Objective-C Files / Objective-C 文件
+- `Moonlight iOS/ViewControllers/StreamFrameViewController.m` - Localized "Starting..." message
+
+### Project Files / 项目文件
+- `Moonlight.xcodeproj/project.pbxproj` - Added LanguagePromptView.swift to project
+
+## Testing Recommendations / 测试建议
+
+1. **Black Screen Recovery**: Test by backgrounding the app, entering immersive scenes, and closing/reopening windows
+2. **Stream Conflicts**: Test by starting a stream, pressing Home, then attempting to start another stream
+3. **Audio Modes**: Test each audio session mode with system media playing
+4. **Language Switching**: Test switching languages in Settings and verify all text updates
+5. **Corner Radius**: Test adjusting corner radius with active streams
+6. **Window Lifecycle**: Test various scenarios: Home button, app backgrounding, window dismissal
+
+## 测试建议
+
+1. **黑屏恢复**: 通过后台化应用、进入沉浸式场景、关闭/重新打开窗口进行测试
+2. **串流冲突**: 通过启动串流、按 Home 键、然后尝试启动另一个串流进行测试
+3. **音频模式**: 在系统媒体播放时测试每种音频会话模式
+4. **语言切换**: 在设置中测试切换语言并验证所有文本更新
+5. **圆角调整**: 在活动串流时测试调整圆角
+6. **窗口生命周期**: 测试各种场景：Home 按钮、应用后台化、窗口关闭
+
+## Notes for Maintainers / 维护者注意事项
+
+- All new features are backward compatible
+- Language preference defaults to English if not set
+- Audio session mode defaults to exclusive (existing behavior)
+- Window corner radius defaults to 0 pixels (for maximum clarity)
+- **Important**: Window corner radius implementation uses `.clipShape()` which may slightly affect rendering sharpness. This is a limitation of SwiftUI/UIKit rendering system. Users can set it to 0 for maximum clarity.
+- All localization uses a helper method pattern for consistency
+
+## 维护者注意事项
+
+- 所有新功能都向后兼容
+- 如果未设置，语言偏好默认为英文
+- 音频会话模式默认为独占（现有行为）
+- 窗口圆角默认 0 像素（以获得最佳清晰度）
+- **重要**: 窗口圆角实现使用 `.clipShape()`，可能会略微影响渲染清晰度。这是 SwiftUI/UIKit 渲染系统的限制。用户可将其设置为 0 以获得最佳清晰度。
+- 所有本地化使用辅助方法模式以保持一致性
+

--- a/Limelight/TemporarySettings.swift
+++ b/Limelight/TemporarySettings.swift
@@ -3,6 +3,59 @@
 import Foundation
 import Observation
 import AppIntents
+import SwiftUI
+
+private let audioSessionModeDefaultsKey = "audioSessionModePreference"
+private let windowCornerRadiusDefaultsKey = "windowCornerRadiusPreference"
+private let appLanguageDefaultsKey = "appLanguagePreference"
+
+@objc public enum AudioSessionMode: Int, CaseIterable, Sendable, Hashable {
+    case exclusive = 0
+    case mixed
+    case exclusiveWhenMicActive
+
+    public var displayName: LocalizedStringKey {
+        switch self {
+        case .exclusive:
+            return "Microphone Exclusive"
+        case .mixed:
+            return "Allow Mixing with Other Audio"
+        case .exclusiveWhenMicActive:
+            return "Exclusive Only When Microphone Active"
+        }
+    }
+    
+    public func localizedDisplayName(for language: AppLanguage) -> String {
+        switch (self, language) {
+        case (.exclusive, .english):
+            return "Microphone Exclusive"
+        case (.exclusive, .chinese):
+            return "麦克风独占"
+        case (.mixed, .english):
+            return "Allow Mixing with Other Audio"
+        case (.mixed, .chinese):
+            return "允许与其他音频混音"
+        case (.exclusiveWhenMicActive, .english):
+            return "Exclusive Only When Microphone Active"
+        case (.exclusiveWhenMicActive, .chinese):
+            return "仅麦克风开启时独占"
+        }
+    }
+}
+
+@objc public enum AppLanguage: Int, CaseIterable, Sendable, Hashable {
+    case english = 0
+    case chinese
+
+    public var displayName: LocalizedStringKey {
+        switch self {
+        case .english:
+            return "English"
+        case .chinese:
+            return "简体中文"
+        }
+    }
+}
 
 #if os(visionOS)
 @Observable
@@ -27,6 +80,9 @@ public class TemporarySettings: NSObject {
     @objc public var multiController = false
     @objc public var swapABXYButtons = false
     @objc public var playAudioOnPC = false
+    @objc public var audioSessionMode: AudioSessionMode = .exclusive
+    @objc public var windowCornerRadius: Double = 0.0
+    @objc public var appLanguageRaw: Int = AppLanguage.english.rawValue
     @objc public var optimizeGames = false
     @objc public var enableHdr = false
     @objc public var btMouseSupport = false
@@ -48,6 +104,18 @@ public class TemporarySettings: NSObject {
         self.realitykitRendererAnimateOpening = false
         self.realitykitRendererCurvature = 0.0
         self.dimPassthrough = false
+        self.windowCornerRadius = (UserDefaults.standard.object(forKey: windowCornerRadiusDefaultsKey) as? Double) ?? 0.0
+        if let storedMode = UserDefaults.standard.object(forKey: audioSessionModeDefaultsKey) as? Int,
+           let mode = AudioSessionMode(rawValue: storedMode) {
+            self.audioSessionMode = mode
+        } else {
+            self.audioSessionMode = .exclusive
+        }
+        if let storedLang = UserDefaults.standard.object(forKey: appLanguageDefaultsKey) as? Int {
+            self.appLanguageRaw = storedLang
+        } else {
+            self.appLanguageRaw = AppLanguage.english.rawValue
+        }
         super.init()
     }
 
@@ -81,6 +149,18 @@ public class TemporarySettings: NSObject {
         self.realitykitRendererAnimateOpening = settings.realitykitRendererAnimateOpening == 1
         self.realitykitRendererCurvature = settings.realitykitRendererCurvature?.floatValue ?? 0
         self.dimPassthrough = settings.dimPassthrough?.boolValue ?? false
+        self.windowCornerRadius = (UserDefaults.standard.object(forKey: windowCornerRadiusDefaultsKey) as? Double) ?? 0.0
+        if let storedMode = UserDefaults.standard.object(forKey: audioSessionModeDefaultsKey) as? Int,
+           let mode = AudioSessionMode(rawValue: storedMode) {
+            self.audioSessionMode = mode
+        } else {
+            self.audioSessionMode = .exclusive
+        }
+        if let storedLang = UserDefaults.standard.object(forKey: appLanguageDefaultsKey) as? Int {
+            self.appLanguageRaw = storedLang
+        } else {
+            self.appLanguageRaw = AppLanguage.english.rawValue
+        }
         #endif
 
         super.init()
@@ -90,6 +170,20 @@ public class TemporarySettings: NSObject {
         // save settings to parent
         let dataManager = DataManager()
         dataManager.saveSettings(withBitrate: Int(bitrate), framerate: Int(framerate), height: Int(height), width: Int(width), audioConfig: Int(audioConfig), onscreenControls: Int(onscreenControls.rawValue), optimizeGames: optimizeGames, multiController: multiController, swapABXYButtons: swapABXYButtons, audioOnPC: playAudioOnPC, preferredCodec: UInt32(preferredCodec.rawValue), renderer: renderer.rawValue, useFramePacing: useFramePacing, enableHdr: enableHdr, btMouseSupport: btMouseSupport, absoluteTouchMode: absoluteTouchMode, statsOverlay: statsOverlay, realitykitRendererAnimateOpening: realitykitRendererAnimateOpening, realitykitRendererCurvature: NSNumber(value: realitykitRendererCurvature), dimPassthrough: dimPassthrough)
+        UserDefaults.standard.set(audioSessionMode.rawValue, forKey: audioSessionModeDefaultsKey)
+        UserDefaults.standard.set(windowCornerRadius, forKey: windowCornerRadiusDefaultsKey)
+        UserDefaults.standard.set(appLanguageRaw, forKey: appLanguageDefaultsKey)
+    }
+}
+
+extension TemporarySettings {
+    var appLanguage: AppLanguage {
+        get {
+            AppLanguage(rawValue: appLanguageRaw) ?? .english
+        }
+        set {
+            appLanguageRaw = newValue.rawValue
+        }
     }
 }
 

--- a/Moonlight Vision/AppsView.swift
+++ b/Moonlight Vision/AppsView.swift
@@ -29,20 +29,9 @@ struct AppsView: View {
                         ProgressView()
                     }
                     AppButtonView(host: host, app: app) {
-                        if (nowLoading != nil) {
-                            return
-                        }
-                        nowLoading = app.id ?? app.name
-                        if let config = viewModel.stream(app: app) {
-                            if (viewModel.streamSettings.renderer == .realitykit) {
-                                openWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
-                                dismissWindow(id: "mainView")
-                            } else {
-                                pushWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
-                                nowLoading = nil
-                            }
-                        }
+                        Task { await handleStreamLaunch(for: app) }
                     }
+                    .environmentObject(viewModel)
                 }
             }
         }
@@ -53,21 +42,94 @@ struct AppsView: View {
                 print("LOAD")
                 viewModel.refreshAppsFor(host: host)
             }
-        }.refreshable() {
+        }
+        .alert(viewModel.localized(english: "Active Stream", chinese: "已有串流窗口"), isPresented: $viewModel.showActiveStreamAlert) {
+            Button(viewModel.localized(english: "Go back to window", chinese: "回到窗口")) {
+                if viewModel.streamSettings.renderer == .realitykit {
+                    openWindow(id: viewModel.streamSettings.renderer.windowId)
+                } else {
+                    pushWindow(id: viewModel.streamSettings.renderer.windowId)
+                }
+            }
+            Button(viewModel.localized(english: "Force quit", chinese: "强制结束"), role: .destructive) {
+                viewModel.forceStopActiveStream()
+                if let pendingApp = viewModel.pendingAppToStream {
+                    Task { await startStream(for: pendingApp) }
+                }
+                viewModel.pendingAppToStream = nil
+            }
+            Button(viewModel.localized(english: "Cancel", chinese: "取消"), role: .cancel) {
+                viewModel.pendingAppToStream = nil
+            }
+        } message: {
+            Text(viewModel.localized(english: "A stream is already running. Please return to that window or terminate it before starting a new one.", chinese: "检测到已有串流窗口在运行。请选择回到该窗口或强制结束后重新启动。"))
+        }
+        .alert(viewModel.localized(english: "Please close the previous window", chinese: "请先关闭旧窗口"), isPresented: $viewModel.showClassicWindowCloseAlert) {
+            Button(viewModel.localized(english: "Got it", chinese: "知道了"), role: .cancel) {}
+        } message: {
+            Text(viewModel.localized(english: "The previous classic window is still open. Please close it before starting another stream.", chinese: "上一次串流已停止，但窗口仍保持打开。请在原窗口横条上点击关闭按钮后再重试。"))
+        }
+        .alert(viewModel.localized(english: "Please close the RealityKit window", chinese: "请先关闭 RealityKit 窗口"), isPresented: $viewModel.showRealityWindowCloseAlert) {
+            Button(viewModel.localized(english: "Got it", chinese: "知道了"), role: .cancel) {}
+        } message: {
+            Text(viewModel.localized(english: "The RealityKit window is still open. Close it before launching another stream.", chinese: "RealityKit 窗口仍保持打开。请关闭后再尝试启动新的串流。"))
+        }
+        .refreshable() {
             print("REFRESH")
             viewModel.refreshAppsFor(host: host)
+        }
+    }
+    
+    @MainActor
+    private func handleStreamLaunch(for app: TemporaryApp) async {
+        guard nowLoading == nil else { return }
+        nowLoading = app.id ?? app.name
+        
+        defer { nowLoading = nil }
+        
+        if viewModel.activelyStreaming {
+            viewModel.pendingAppToStream = app
+            viewModel.showActiveStreamAlert = true
+            return
+        }
+        
+        if viewModel.streamSettings.renderer == .classic {
+            if viewModel.classicWindowNeedsManualClose {
+                viewModel.showClassicWindowCloseAlert = true
+                return
+            }
+        } else {
+            if viewModel.realityWindowNeedsManualClose {
+                viewModel.showRealityWindowCloseAlert = true
+                return
+            }
+        }
+        
+        await startStream(for: app)
+    }
+    
+    @MainActor
+    private func startStream(for app: TemporaryApp) async {
+        guard let config = viewModel.stream(app: app) else { return }
+        if viewModel.streamSettings.renderer == .realitykit {
+            openWindow(id: viewModel.streamSettings.renderer.windowId, value: config)
+            dismissWindow(id: "mainView")
+        } else {
+            openWindow(id: "classicStreamingWindow", value: config)
+            dismissWindow(id: "mainView")
         }
     }
 }
 
 struct AppButtonView: View {
+    @EnvironmentObject private var viewModel: MainViewModel
     let host: TemporaryHost
     let app: TemporaryApp
     let action: () -> Void
     
     var body: some View {
-        Button(app.name ?? "Unknown", action: action)
-            .badge(Text(app.id == host.currentGame ? "Running" : ""))
+        Button(app.name ?? viewModel.localized(english: "Unknown", chinese: "未知"), action: action)
+            .badge(Text(app.id == host.currentGame ? viewModel.localized(english: "Running", chinese: "运行中") : ""))
             .contextMenu {
                 if app.id == host.currentGame {
                     Button {
@@ -79,7 +141,7 @@ struct AppButtonView: View {
                             // lol no error handling...
                         }
                     } label: {
-                        Label("Stop", systemImage: "stop.circle")
+                        Label(viewModel.localized(english: "Stop", chinese: "停止"), systemImage: "stop.circle")
                     }
                 }
             }

--- a/Moonlight Vision/AudioHelpers.swift
+++ b/Moonlight Vision/AudioHelpers.swift
@@ -1,32 +1,28 @@
-//
-//  AudioHelpers.swift
-//  Moonlight
-//
-//  Created by Max Thomas on 2/6/25.
-//  Copyright © 2025 Moonlight Game Streaming Project. All rights reserved.
-//
+import AVFAudio
+import UIKit
 
 class AudioHelpers {
-
-    private static func fixCategoryAndMic() {
+    private static func configureAudioSession(exclusive: Bool) {
         let audioSession = AVAudioSession.sharedInstance()
         do {
+            if exclusive {
+                try audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .allowBluetoothA2DP, .allowAirPlay])
+                try audioSession.setMode(.voiceChat)
+                try audioSession.setPreferredInputNumberOfChannels(1)
+            } else {
+                try audioSession.setCategory(.playback, options: [.mixWithOthers])
+                try audioSession.setMode(.moviePlayback)
+            }
             try audioSession.setActive(true)
-            try audioSession.setCategory(.playAndRecord, options: [.mixWithOthers, .allowBluetoothA2DP, .allowAirPlay])
-            try audioSession.setMode(.voiceChat)
-            try audioSession.setPreferredInputNumberOfChannels(1)
-        }
-        catch {
+        } catch {
             print("Failed to set the audio session mic/category configuration?")
         }
     }
 
-    /// Ensure that the audio session is direct stereo
-    /// Also ensures that the microphone uses voice chat noise cancellation.
-    static func fixAudioForDirectStereo() {
+    static func fixAudioForDirectStereo(exclusive: Bool = true) {
         print("AudioHelpers - Fix for direct stereo")
-        AudioHelpers.fixCategoryAndMic()
-        
+        configureAudioSession(exclusive: exclusive)
+
         let audioSession = AVAudioSession.sharedInstance()
         do {
             try audioSession.setPreferredOutputNumberOfChannels(2)
@@ -35,45 +31,36 @@ class AudioHelpers {
             print("Failed to set the audio session configuration?")
         }
     }
-    
-    /// Ensure that the audio session is surround and anchored to the active window
-    /// Also ensures that the microphone uses voice chat noise cancellation.
-    static func fixAudioForSurroundForCurrentWindow() {
-        AudioHelpers.fixCategoryAndMic()
-        
+
+    static func fixAudioForSurroundForCurrentWindow(exclusive: Bool = true) {
+        configureAudioSession(exclusive: exclusive)
+
         let audioSession = AVAudioSession.sharedInstance()
         do {
             if let id = UIApplication.shared.connectedScenes.first?.session.persistentIdentifier {
                 print("AudioHelpers - Found current window \(id)")
-
-                // TODO(shinyquagsire23): Not sure how this would interact w/ surround sound or Dolby
                 try audioSession.setPreferredOutputNumberOfChannels(audioSession.maximumOutputNumberOfChannels)
                 try audioSession.setIntendedSpatialExperience(.headTracked(soundStageSize: .medium, anchoringStrategy: .scene(identifier: id)))
-            }
-            else {
+            } else {
                 print("AudioHelpers - Couldn't find current window?")
-                fixAudioForDirectStereo()
+                fixAudioForDirectStereo(exclusive: exclusive)
             }
         } catch {
             print("Failed to set the audio session configuration?")
         }
     }
-    
-    static func fixAudioForSurroundForUIKitWindow(_ window: UIWindow) {
-        AudioHelpers.fixCategoryAndMic()
-        
+
+    static func fixAudioForSurroundForUIKitWindow(_ window: UIWindow, exclusive: Bool = true) {
+        configureAudioSession(exclusive: exclusive)
+
         let audioSession = AVAudioSession.sharedInstance()
         do {
-            print(window, window.windowScene?.session.persistentIdentifier)
             if let id = window.windowScene?.session.persistentIdentifier {
                 print("AudioHelpers - Found UIKit window \(id)")
-                
-                // TODO(shinyquagsire23): Not sure how this would interact w/ surround sound or Dolby
                 try audioSession.setPreferredOutputNumberOfChannels(audioSession.maximumOutputNumberOfChannels)
                 try audioSession.setIntendedSpatialExperience(.headTracked(soundStageSize: .medium, anchoringStrategy: .scene(identifier: id)))
-            }
-            else {
-                fixAudioForDirectStereo()
+            } else {
+                fixAudioForDirectStereo(exclusive: exclusive)
             }
         } catch {
             print("AudioHelpers - Couldn't find UIKit window?")

--- a/Moonlight Vision/ComputerView.swift
+++ b/Moonlight Vision/ComputerView.swift
@@ -32,7 +32,7 @@ struct ComputerView: View {
             // --- Handle Main States ---
             if host.updatePending {
                 // Show a generic updating indicator when manually refreshed or during initial task update
-                ProgressView("Updating \(host.name)...")
+                ProgressView(viewModel.localized(english: "Updating \(host.name)...", chinese: "正在更新 \(host.name)..."))
                     .scaleEffect(1.5) // Make spinner larger
             } else {
                 // Switch based on the host's primary state (Online, Offline, Unknown)
@@ -49,7 +49,7 @@ struct ComputerView: View {
                     offlineView
                 case .unknown:
                     // Waiting for initial discovery or update to determine state
-                    ProgressView("Connecting to \(host.name)...")
+                    ProgressView(viewModel.localized(english: "Connecting to \(host.name)...", chinese: "正在连接到 \(host.name)..."))
                         .scaleEffect(1.5)
                 // No default needed if HostState enum covers all cases explicitly
                 }
@@ -77,7 +77,7 @@ struct ComputerView: View {
                         }
                     }
                 } label: {
-                    Label("Refresh Status", systemImage: "arrow.clockwise")
+                    Label(viewModel.localized(english: "Refresh Status", chinese: "刷新状态"), systemImage: "arrow.clockwise")
                 }
                 .disabled(host.updatePending)
             }
@@ -118,21 +118,26 @@ struct ComputerView: View {
         }
         // Use the view model's pairing state for the alert, as pairing is a global action
         .alert(
-            "Pairing",
+            viewModel.localized(english: "Pairing", chinese: "配对"),
             isPresented: $viewModel.pairingInProgress,
             presenting: viewModel.currentPin // Use the PIN from the ViewModel
         ) { pinData in // Action buttons using the presented data (PIN)
-            Button("Cancel", role: .cancel) {
+            Button(viewModel.localized(english: "Cancel", chinese: "取消"), role: .cancel) {
                 viewModel.endPairing() // Call ViewModel's cancel function
             }
         } message: { pinData in // Message using the presented data (PIN)
             // Ensure currentPin is properly published and updated in ViewModel
-            Text("""
+            Text(viewModel.localized(english: """
             Enter the following PIN on the host machine:
             \(pinData)
 
             If your host PC is running Sunshine, navigate to the Sunshine web UI to enter the PIN.
-            """)
+            """, chinese: """
+            请在主机上输入以下 PIN：
+            \(pinData)
+
+            如果您的 PC 运行的是 Sunshine，请导航到 Sunshine Web UI 输入 PIN。
+            """))
         }
     }
 
@@ -151,16 +156,16 @@ struct ComputerView: View {
         case .unpaired:
             // Host is Online but Unpaired -> Show Pairing UI
             VStack(spacing: 15) {
-                 Label("Ready to Pair", systemImage: "lock.desktopcomputer")
+                 Label(viewModel.localized(english: "Ready to Pair", chinese: "准备配对"), systemImage: "lock.desktopcomputer")
                      .font(.title2)
                      .foregroundColor(.orange) // Use a distinct color
 
-                Text("This computer is online but needs to be paired with this device.")
+                Text(viewModel.localized(english: "This computer is online but needs to be paired with this device.", chinese: "此电脑已在线，但需要与此设备配对。"))
                      .font(.body)
                      .multilineTextAlignment(.center)
                      .padding(.horizontal)
 
-                Button("Start Pairing") {
+                Button(viewModel.localized(english: "Start Pairing", chinese: "开始配对")) {
                     // ViewModel should handle checking if host is online again if necessary,
                     // but ComputerView already knows it's online here.
                     viewModel.tryPairHost(host)
@@ -172,14 +177,14 @@ struct ComputerView: View {
         case .unknown:
              // Host is Online, but we haven't determined pairing status yet
              VStack(spacing: 15) {
-                 Label("Checking Pairing Status...", systemImage: "questionmark.circle")
+                 Label(viewModel.localized(english: "Checking Pairing Status...", chinese: "正在检查配对状态..."), systemImage: "questionmark.circle")
                       .font(.title2)
                       .foregroundColor(.gray) // Indicate uncertainty
                  ProgressView()
                       .padding(.bottom)
 
                  // Option to force pairing attempt
-                 Button("Start Pairing Anyway") {
+                 Button(viewModel.localized(english: "Start Pairing Anyway", chinese: "仍然开始配对")) {
                      print("User initiated pairing while pairState is unknown for \(host.name).")
                      viewModel.tryPairHost(host)
                  }
@@ -187,7 +192,7 @@ struct ComputerView: View {
                  // The alert is attached higher up in the view hierarchy
 
                  // Option to stop automatic background checks for this view instance
-                 Button("Stop Automatic Checks") {
+                 Button(viewModel.localized(english: "Stop Automatic Checks", chinese: "停止自动检查")) {
                      print("User stopped automatic checks for \(host.name).")
                      stopAutomaticStateUpdate = true // Stop this view's task modifier
                      // Optionally tell ViewModel to pause background *polling* if implemented
@@ -204,10 +209,10 @@ struct ComputerView: View {
     /// View displayed when the host is offline.
     private var offlineView: some View {
         VStack(spacing: 15) {
-            Label("Offline", systemImage: "desktopcomputer.trianglebadge.exclamationmark")
+            Label(viewModel.localized(english: "Offline", chinese: "离线"), systemImage: "desktopcomputer.trianglebadge.exclamationmark")
                 .font(.title2)
                 .foregroundColor(.red) // Clear offline indicator
-            Text("Moonlight cannot connect to this computer. Ensure it is turned on and connected to the network.")
+            Text(viewModel.localized(english: "Moonlight cannot connect to this computer. Ensure it is turned on and connected to the network.", chinese: "Moonlight 无法连接到此电脑。请确保它已开机并连接到网络。"))
                 .font(.body)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
@@ -229,14 +234,14 @@ struct ComputerView: View {
                     }
                 }
             } label: {
-                Label("Force Refresh Status", systemImage: "arrow.clockwise")
+                Label(viewModel.localized(english: "Force Refresh Status", chinese: "强制刷新状态"), systemImage: "arrow.clockwise")
             }
             .disabled(host.updatePending)
             // Wake-on-LAN button
             Button {
                 viewModel.wakeHost(host)
             } label: {
-                Label("Wake PC", systemImage: "sun.horizon")
+                Label(viewModel.localized(english: "Wake PC", chinese: "唤醒电脑"), systemImage: "sun.horizon")
             }
             .controlSize(.large)
             // Disable if MAC address is missing or invalid

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -460,7 +460,8 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
                 
                 VTDecompressionSessionCreate(allocator: kCFAllocatorDefault, formatDescription: formatDesc, decoderSpecification: decoderConfiguration as CFDictionary, imageBufferAttributes: attributes as CFDictionary, outputCallback: &decoderCallback, decompressionSessionOut: &session)
                 
-                AudioHelpers.fixAudioForSurroundForCurrentWindow() // TODO(shinyquagsire23): Make this configurable?
+                let exclusive = MainViewModel.shouldUseExclusiveAudio(microphoneActive: false)
+                AudioHelpers.fixAudioForSurroundForCurrentWindow(exclusive: exclusive) // TODO(shinyquagsire23): Make this configurable?
             } else {
                 // Couldn't create format description yet
 //                free(dataPtr)

--- a/Moonlight Vision/LanguagePromptView.swift
+++ b/Moonlight Vision/LanguagePromptView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct LanguagePromptView: View {
+    @EnvironmentObject private var viewModel: MainViewModel
+    @State private var selection: AppLanguage = .english
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Text(viewModel.localized(english: "Choose your language", chinese: "请选择界面语言"))
+                    .font(.title2)
+                    .multilineTextAlignment(.center)
+                    .padding(.top)
+
+                Picker(viewModel.localized(english: "Language", chinese: "语言"), selection: $selection) {
+                    ForEach(AppLanguage.allCases, id: \.self) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .pickerStyle(.inline)
+
+                Button {
+                    viewModel.updateLanguage(selection)
+                } label: {
+                    Text(viewModel.localized(english: "Continue", chinese: "继续"))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal)
+            }
+            .padding()
+            .onAppear { selection = viewModel.currentLanguage }
+        }
+    }
+}

--- a/Moonlight Vision/MainContentView.swift
+++ b/Moonlight Vision/MainContentView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct MainContentView: View {
     @EnvironmentObject private var viewModel: MainViewModel
+    @Environment(\.dismissWindow) private var dismissWindow
 
     @State private var selectedHost: TemporaryHost?
 
@@ -32,22 +33,22 @@ struct MainContentView: View {
                             hostRow(for: host)
                         }
                     }
-                    .alert("Really delete?", isPresented: $isDeletingHost) {
-                        Button("Yes, delete it", role: .destructive) {
+                    .alert(viewModel.localized(english: "Really delete?", chinese: "确定要删除吗？"), isPresented: $isDeletingHost) {
+                        Button(viewModel.localized(english: "Yes, delete it", chinese: "是的，删除"), role: .destructive) {
                             if let hostToDelete {
                                 viewModel.removeHost(hostToDelete)
                                 selectedHost = nil
                                 showDeletionTriggeredMessage = false
                             }
                         }
-                        Button("Cancel", role: .cancel) {
+                        Button(viewModel.localized(english: "Cancel", chinese: "取消"), role: .cancel) {
                             isDeletingHost = false
                             hostToDelete = nil
                             showDeletionTriggeredMessage = false
                         }
                     }
-                    .navigationTitle("Computers") // Keep simple navigation title
-                    Text("Please actually read the Change Log")
+                    .navigationTitle(viewModel.localized(english: "Computers", chinese: "电脑"))
+                    Text(viewModel.localized(english: "Please actually read the Change Log", chinese: "请务必阅读更新日志"))
                         .font(.system(size: 10)) // Even smaller font size for the second line
                         .foregroundColor(.gray)
                         .padding(.bottom) // Add bottom padding for visual spacing
@@ -60,7 +61,7 @@ struct MainContentView: View {
                             viewModel.stopRefresh()
                         }
                     } label: {
-                        Text(isRefreshingDiscovery ? "Click here to Stop network discovery, or if things are unresponsive" : "Click here to scans for Hosts") // Conditional Text
+                        Text(isRefreshingDiscovery ? viewModel.localized(english: "Click here to Stop network discovery, or if things are unresponsive", chinese: "点击此处停止网络发现，或如果无响应") : viewModel.localized(english: "Click here to scans for Hosts", chinese: "点击此处扫描主机")) // Conditional Text
                             .font(.caption)
                             .foregroundColor(.gray)
                     }
@@ -69,25 +70,25 @@ struct MainContentView: View {
                 }
                 .toolbar { // Keep the toolbar as is for now
                     ToolbarItem(placement: .primaryAction) {
-                        Button("Add Server", systemImage: "plus") {
+                        Button(viewModel.localized(english: "Add Server", chinese: "添加服务器"), systemImage: "plus") {
                             addingHost = true
                         }.alert(
-                            "Enter server",
+                            viewModel.localized(english: "Enter server", chinese: "输入服务器"),
                             isPresented: $addingHost
                         ) {
-                            TextField("IP or Host", text: $newHostIp)
-                            Button("Add") {
+                            TextField(viewModel.localized(english: "IP or Host", chinese: "IP 或主机名"), text: $newHostIp)
+                            Button(viewModel.localized(english: "Add", chinese: "添加")) {
                                 addingHost = false
                                 viewModel.manuallyDiscoverHost(hostOrIp: newHostIp)
                             }
-                            Button("Cancel", role: .cancel) {
+                            Button(viewModel.localized(english: "Cancel", chinese: "取消"), role: .cancel) {
                                 addingHost = false
                             }
                         }.alert(
-                            "Unable to add host",
+                            viewModel.localized(english: "Unable to add host", chinese: "无法添加主机"),
                             isPresented: $viewModel.errorAddingHost
                         ) {
-                            Button("Ok", role: .cancel) {
+                            Button(viewModel.localized(english: "Ok", chinese: "确定"), role: .cancel) {
                                 viewModel.errorAddingHost = true
                             }
                         } message: {
@@ -97,7 +98,7 @@ struct MainContentView: View {
                 }
             } detail: {
                 if showDeletionTriggeredMessage {
-                    Text("Host deletion triggered")
+                    Text(viewModel.localized(english: "Host deletion triggered", chinese: "主机删除已触发"))
                 }
                 else if let selectedHost = Binding<TemporaryHost>($selectedHost) {
                     ComputerViewWrapper(selectedHost: $selectedHost)
@@ -105,12 +106,12 @@ struct MainContentView: View {
                 } else {
                     // If the 'if let' above failed, it means the @State variable selectedHost was nil.
                     // Display the placeholder view in this case.
-                    Text("No host selected")
+                    Text(viewModel.localized(english: "No host selected", chinese: "未选择主机"))
                         .navigationTitle("") // Optionally clear title when nothing is selected
                 }
 
             }.tabItem {
-                Label("Computers", systemImage: "desktopcomputer")
+                Label(viewModel.localized(english: "Computers", chinese: "电脑"), systemImage: "desktopcomputer")
             }
             .task {
                 viewModel.loadSavedHosts()
@@ -141,17 +142,25 @@ struct MainContentView: View {
                 NotificationCenter.default.removeObserver(self)
             }
 
-            SettingsView(settings: $viewModel.streamSettings).tabItem {
-                Label("Settings", systemImage: "gear")
-            }
+            SettingsView(settings: $viewModel.streamSettings)
+                .environmentObject(viewModel)
+                .tabItem {
+                    Label(viewModel.localized(english: "Settings", chinese: "设置"), systemImage: "gear")
+                }
 
-            UpdatesView().tabItem {
-                Label("Changelog", systemImage: "info.circle.fill")
-            }
+            UpdatesView()
+                .environmentObject(viewModel)
+                .tabItem {
+                    Label(viewModel.localized(english: "Changelog", chinese: "更新日志"), systemImage: "info.circle.fill")
+                }
 
         }
+        .sheet(isPresented: $viewModel.showLanguagePrompt) {
+            LanguagePromptView()
+                .environmentObject(viewModel)
+        }
     }
-
+    
     private func hostRow(for host: TemporaryHost) -> some View {
         Label {
             Text(host.name)
@@ -167,7 +176,7 @@ struct MainContentView: View {
                  Button {
                      viewModel.wakeHost(host)
                  } label: {
-                     Label("Wake PC", systemImage: "sun.horizon")
+                     Label(viewModel.localized(english: "Wake PC", chinese: "唤醒电脑"), systemImage: "sun.horizon")
                  }
                  .disabled(host.mac == nil || host.mac == "00:00:00:00:00:00") // Disable if MAC is missing
              }
@@ -177,7 +186,7 @@ struct MainContentView: View {
                   Button {
                       viewModel.tryPairHost(host)
                   } label: {
-                      Label("Pair", systemImage: "lock.open.desktopcomputer")
+                      Label(viewModel.localized(english: "Pair", chinese: "配对"), systemImage: "lock.open.desktopcomputer")
                   }
              }
 
@@ -188,7 +197,7 @@ struct MainContentView: View {
                 isDeletingHost = true
                 hostToDelete = host
             } label: {
-                Label("Delete PC", systemImage: "trash")
+                Label(viewModel.localized(english: "Delete PC", chinese: "删除电脑"), systemImage: "trash")
             }
         }
         // Add an overlay or badge for specific states if desired

--- a/Moonlight Vision/MainViewModel.swift
+++ b/Moonlight Vision/MainViewModel.swift
@@ -13,6 +13,7 @@ import AVFoundation
 
 @MainActor
 class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback, AppAssetCallback {
+    private let languagePromptDefaultsKey = "didCompleteLanguagePrompt"
     @objc
     static let shared = MainViewModel()
 
@@ -26,6 +27,16 @@ class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback
 
     @Published var currentStreamConfig = StreamConfiguration()
     @Published var activelyStreaming = false
+    @Published var showActiveStreamAlert = false
+    @Published var pendingAppToStream: TemporaryApp?
+    @Published var showLanguagePrompt = false
+    
+    // Store saved window size for aspect ratio lock restoration
+    @Published var savedStreamWindowSize: CGSize? = nil
+    @Published var classicWindowNeedsManualClose = false
+    @Published var realityWindowNeedsManualClose = false
+    @Published var showClassicWindowCloseAlert = false
+    @Published var showRealityWindowCloseAlert = false
     @Published var streamSettings: TemporarySettings
 
     @Published var volumeSliderValue: Float = 1.0
@@ -52,6 +63,7 @@ class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback
         clientCert = CryptoManager.readCertFromFile()
         uniqueId = IdManager.getUniqueId()
         streamSettings = dataManager.getSettings()
+        showLanguagePrompt = !UserDefaults.standard.bool(forKey: languagePromptDefaultsKey)
 
         super.init()
         appManager = AppAssetManager(callback: self)
@@ -481,9 +493,66 @@ class MainViewModel: NSObject, ObservableObject, DiscoveryCallback, PairCallback
         print("stream - Final supportedVideoFormats: \(String(format: "0x%04X", config.supportedVideoFormats))")
 
         currentStreamConfig = config
+        classicWindowNeedsManualClose = false
+        realityWindowNeedsManualClose = false
         activelyStreaming = true
         print("stream - Stream configuration complete. Ready to start streaming.")
         return currentStreamConfig
+    }
+
+    func updateLanguage(_ language: AppLanguage) {
+        streamSettings.appLanguage = language
+        streamSettings.save()
+        showLanguagePrompt = false
+        UserDefaults.standard.set(true, forKey: languagePromptDefaultsKey)
+    }
+
+    func forceStopActiveStream() {
+        activelyStreaming = false
+        classicWindowNeedsManualClose = false
+        realityWindowNeedsManualClose = false
+    }
+
+    nonisolated static func audioSessionMode() -> AudioSessionMode {
+        return MainActor.assumeIsolated {
+            MainViewModel.shared.streamSettings.audioSessionMode
+        }
+    }
+
+
+    var currentLanguage: AppLanguage {
+        streamSettings.appLanguage
+    }
+
+    func localized(english: String, chinese: String) -> String {
+        currentLanguage == .chinese ? chinese : english
+    }
+
+    nonisolated static func localizedStatic(english: String, chinese: String) -> String {
+        return MainActor.assumeIsolated {
+            MainViewModel.shared.streamSettings.appLanguage == .chinese ? chinese : english
+        }
+    }
+    
+    @objc nonisolated static func localizedString(english: String, chinese: String) -> String {
+        return localizedStatic(english: english, chinese: chinese)
+    }
+    
+    @objc nonisolated static func startingStreamFormatString() -> String {
+        return localizedStatic(english: "Starting %@...", chinese: "正在启动 %@...")
+    }
+
+    nonisolated static func shouldUseExclusiveAudio(microphoneActive: Bool) -> Bool {
+        return MainActor.assumeIsolated {
+            switch MainViewModel.shared.streamSettings.audioSessionMode {
+            case .exclusive:
+                return true
+            case .mixed:
+                return false
+            case .exclusiveWhenMicActive:
+                return microphoneActive
+            }
+        }
     }
 }
 

--- a/Moonlight Vision/MoonlightVisionApp.swift
+++ b/Moonlight Vision/MoonlightVisionApp.swift
@@ -35,7 +35,8 @@ struct MoonlightVisionApp: SwiftUI.App {
                     streamConfig.wrappedValue = nil
                 }
                 .onChange(of: appDelegate.mainViewModel) {
-                    AudioHelpers.fixAudioForSurroundForCurrentWindow()
+                    let exclusive = MainViewModel.shouldUseExclusiveAudio(microphoneActive: false)
+                    AudioHelpers.fixAudioForSurroundForCurrentWindow(exclusive: exclusive)
                 }
         }
         .windowStyle(.volumetric)

--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -32,6 +32,7 @@ struct RealityKitStreamView: View {
     // @EnvironmentObject private var viewModel: MainViewModel // Not needed here
     
     var body: some View {
+        let cornerRadius = CGFloat(MainViewModel.shared.streamSettings.windowCornerRadius)
         if streamConfig != nil {
             _RealityKitStreamView(streamConfig: Binding<StreamConfiguration>(
                 get: { streamConfig ?? StreamConfiguration() },
@@ -44,10 +45,31 @@ struct RealityKitStreamView: View {
                 
                 // We keep the original logic here for safety/cleanup.
                 dismissWindow()
+                dismissWindow(id: "realitykitStreamingWindow")
                 streamConfig = nil
             }
         } else {
-            ProgressView().onAppear { dismissWindow() }
+            VStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.largeTitle)
+                Text(MainViewModel.localizedStatic(english: "Stream stopped", chinese: "串流已停止"))
+                    .font(.title2)
+                Text(MainViewModel.localizedStatic(english: "Please close this window before starting a new stream from the main menu.", chinese: "请在窗口横条上点击关闭按钮，之后即可在主菜单重新启动串流。"))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.thinMaterial)
+            .onAppear {
+                Task { @MainActor in
+                    MainViewModel.shared.realityWindowNeedsManualClose = true
+                }
+            }
+            .onDisappear {
+                Task { @MainActor in
+                    MainViewModel.shared.realityWindowNeedsManualClose = false
+                }
+            }
         }
     }
 }
@@ -69,6 +91,8 @@ struct _RealityKitStreamView: View {
     @State private var depthOffset: Float = 1.0
     
     @State var shouldClose: Bool = false
+    @State private var needsResume = false
+    @State private var didPerformFullClose = false
 
 
     var isSBSVideo: Bool {
@@ -119,7 +143,9 @@ struct _RealityKitStreamView: View {
     }
 
     var body: some View {
-        GeometryReader3D { proxy in
+        if viewModel.activelyStreaming {
+            let cornerRadius = CGFloat(viewModel.streamSettings.windowCornerRadius)
+            GeometryReader3D { proxy in
                 RealityView { content in
                     let mesh = try! _RealityKitStreamView.generateCurvedPlane(width: MAX_WIDTH_METERS, aspectRatio: aspectRatio, resulotion: (100,100), curveMagnitude: viewModel.streamSettings.realitykitRendererCurvature * curveAnimationMultiplier)
                     let colBox = ShapeResource.generateBox(width: 2, height: 2 * aspectRatio, depth: 0.001).offsetBy(translation: .init(x: 0, y: -0.43, z: 1))
@@ -161,12 +187,11 @@ struct _RealityKitStreamView: View {
         .ornament(visibility: connectionCallbacks.showAlert ? .visible :  .hidden , attachmentAnchor: .scene(.bottomFront), contentAlignment: .bottom) {
             VStack(alignment: .center) {
                 Image(systemName: "exclamationmark.triangle")
-                Text("Stream error")
+                Text(MainViewModel.localizedStatic(english: "Stream error", chinese: "串流错误"))
                     .font(.title)
-                Text(connectionCallbacks.errorMessage ?? "Unknown error")
-                Button("Close") {
+                Text(connectionCallbacks.errorMessage ?? MainViewModel.localizedStatic(english: "Unknown error", chinese: "未知错误"))
+                Button(MainViewModel.localizedStatic(english: "Close", chinese: "关闭")) {
                     shouldClose.toggle()
-                    dismissWindow()
                 }
             }
             .padding()
@@ -179,22 +204,11 @@ struct _RealityKitStreamView: View {
                             horizontal: false,
                             streamConfig: $streamConfig,
                             closeAction: {
-                                // This is the action for the HOME BUTTON inside StreamControls
-                                
-                                // 1. Tell the app we are no longer streaming
-                                viewModel.activelyStreaming = false
-                                
-                                // 2. Stop the stream manager and cleanup controllers
-                                self._streamMan?.stopStream()
-                                self.controllerSupport?.cleanup()
-                                
-                                openWindow(id: "mainView")
-                                
-                                self.closeAction()
+                                handleUserRequestedClose()
                             }
                         ) {
                 HStack {
-                    Button("Flatten", systemImage: viewModel.streamSettings.realitykitRendererCurvature == 0 ? "light.panel" : "pano.fill") {
+                    Button(viewModel.localized(english: "Flatten", chinese: "扁平化"), systemImage: viewModel.streamSettings.realitykitRendererCurvature == 0 ? "light.panel" : "pano.fill") {
                         if viewModel.streamSettings.realitykitRendererCurvature == 0 {
                             viewModel.streamSettings.realitykitRendererCurvature = curveMagnitudeMemory
                         } else {
@@ -218,7 +232,7 @@ struct _RealityKitStreamView: View {
                     Button("arrow.left.and.line.horizontal.and.arrow.right", systemImage: "arrow.left.and.line.horizontal.and.right.down") {                         // Optional: Action for the button, e.g., reset depth
                          depthOffset = -1.0 // Reset to default example
                     }
-                    .accessibilityLabel("Adjust Depth") // Accessibility
+                    .accessibilityLabel(viewModel.localized(english: "Adjust Depth", chinese: "调整深度")) // Accessibility
                     Slider(value: $depthOffset, in: -1.5 ... 2.5, step: 0.01) // Adjust range as needed
                         .frame(width: 300)
                         .padding([.trailing])
@@ -226,7 +240,7 @@ struct _RealityKitStreamView: View {
                 }
 
                 HStack {
-                    Button("3D Mode", systemImage: videoMode == .standard2D ? "rectangle" : "rectangle.split.2x1") {
+                    Button(viewModel.localized(english: "3D Mode", chinese: "3D 模式"), systemImage: videoMode == .standard2D ? "rectangle" : "rectangle.split.2x1") {
                         videoMode = videoMode == .standard2D ? .sideBySide3D : .standard2D
                         if videoMode == .sideBySide3D {
                             screen.model?.materials = [surfaceMaterial!]
@@ -251,7 +265,7 @@ struct _RealityKitStreamView: View {
                             //                            effect.scaleEffect(x: isActive ? 1: 0.5, y: 1, anchor: .leading)
                         }
                 }
-                Button("Main Button", systemImage: "gamecontroller.fill") {
+                Button(viewModel.localized(english: "Main Button", chinese: "主按钮"), systemImage: "gamecontroller.fill") {
 //                    self.controllerSupport?.updateTriggers(<#T##controller: Controller!##Controller!#>, left: <#T##UInt8#>, right: <#T##UInt8#>)
                 }.simultaneousGesture(
                     DragGesture(minimumDistance: 0)
@@ -271,85 +285,152 @@ struct _RealityKitStreamView: View {
             }
         }
         .onAppear {
-                    
-                    // --- START FIX ---
-                            // Check if the ViewModel thinks a stream is active.
-                            // If the app was restarted or resumed from sleep, `activelyStreaming` will be false.
-                            if !viewModel.activelyStreaming {
-                                print("_RealityKitStreamView: Detected appearance without active stream state. Closing stream window and opening main view.")
-                                
-                                // 1. Explicitly open the main window.
-                                openWindow(id: "mainView")
-                                
-                                // 2. Call the close action to dismiss this window and nil the config.
-                                self.closeAction()
-                                
-                                // 3. Stop processing the rest of onAppear.
-                                return
-                            }
-                            // --- END FIX ---
-                    
-                    dismissWindow(id: "mainView")
-                    dismissWindow(id: "dummy")
-        //            dismissWindow(id: "realitykitStreamingWindow")
-                    self.curveAnimationMultiplier = viewModel.streamSettings.realitykitRendererAnimateOpening ? 0 : 1
-                    self._streamMan = StreamManager(
-                        config: self.streamConfig,
-                        rendererProvider: {
-                            DrawableVideoDecoder(texture: self.texture, callbacks: self.connectionCallbacks, aspectRatio: Float(self.streamConfig.width) / Float(self.streamConfig.height), useFramePacing: self.streamConfig.useFramePacing, enableHDR: self.viewModel.streamSettings.enableHdr) { texture, correctedResultion in
-                                DispatchQueue.main.async {
-                                    if let correctedResultion = correctedResultion {
-                                        streamConfig.width = Int32(correctedResultion.0)
-                                        streamConfig.height = Int32(correctedResultion.1)
-                                    }
-                                    self.texture.replace(withDrawables: texture)
-                                    
-                                    // --- REMOVE THIS LINE ---
-                                    // screen.model!.materials = [UnlitMaterial(texture: self.texture)] // <-- THIS LINE CAUSES THE BLACK SCREEN
-                                    // ---
-                                    
-                                    self.controllerSupport!.connectionEstablished()
-                                    if self.curveAnimationMultiplier == 0 { animateOpening() }
-                                }
-                            }
-                        },
-                        connectionCallbacks: self.connectionCallbacks
-                    )
-                    let operationQueue = OperationQueue()
-            operationQueue.addOperation(_streamMan!)
+            guard handleAppearanceValidation() else { return }
+            startStreamIfNeeded()
         }
         .onChange(of: shouldClose) { _, shouldClose in
             if shouldClose {
-                openWindow(id: "mainView")
-                dismissWindow()
+                handleUserRequestedClose()
             }
         }
         .onChange(of: scenePhase) { _, phase in
             switch phase {
             case .active:
-                // print("active")
-                break
-            case .inactive:
-                print("inactive")
-                break
+                if needsResume, viewModel.activelyStreaming {
+                    // Add a small delay to ensure we're truly back from background
+                    // This prevents resuming when just switching between regular apps
+                    Task {
+                        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 second delay
+                        if needsResume, viewModel.activelyStreaming {
+                            await MainActor.run {
+                                startStreamIfNeeded()
+                            }
+                        }
+                    }
+                }
             case .background:
-                print("background")
-                viewModel.activelyStreaming = false
-                _streamMan?.stopStream()
-                _streamMan = nil
-                controllerSupport?.cleanup()
-//                streamConfig = nil
-                if !shouldClose { openWindow(id: "mainView") }
-                self.closeAction()
-//                dismissWindow()
-            @unknown default: break
-                // print("unknown default")
+                // Only pause when truly backgrounded (e.g., immersive scene or headset removal)
+                // Don't pause on .inactive as it triggers too easily when switching apps
+                pauseStreamForBackground()
+            default:
+                break
             }
         }
         .persistentSystemOverlays(viewModel.streamSettings.dimPassthrough ? .hidden : .automatic)
         .preferredSurroundingsEffect(viewModel.streamSettings.dimPassthrough ? .systemDark : nil)
         .volumeBaseplateVisibility(viewModel.streamSettings.dimPassthrough ? .hidden : .automatic)
-        .supportedVolumeViewpoints(.front)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .supportedVolumeViewpoints(.front)
+            .onDisappear {
+                handleSceneDisappearance()
+            }
+        } else {
+            VStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.largeTitle)
+                Text(viewModel.localized(english: "Stream stopped", chinese: "串流已停止"))
+                    .font(.title2)
+                Text(viewModel.localized(english: "Please close this window before starting a new stream from the main menu.", chinese: "请在窗口横条上点击关闭按钮，之后即可在主菜单重新启动串流。"))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.thinMaterial)
+        }
+    }
+
+    private func handleAppearanceValidation() -> Bool {
+        if !viewModel.activelyStreaming {
+            print("_RealityKitStreamView: Detected appearance without active stream state. Closing stream window and opening main view.")
+            openWindow(id: "mainView")
+            self.closeAction()
+            return false
+        }
+        return true
+    }
+
+    private func startStreamIfNeeded() {
+        guard _streamMan == nil else {
+            needsResume = false
+            return
+        }
+
+        dismissWindow(id: "mainView")
+        dismissWindow(id: "dummy")
+
+        self.curveAnimationMultiplier = viewModel.streamSettings.realitykitRendererAnimateOpening ? 0 : 1
+        didPerformFullClose = false
+        self._streamMan = StreamManager(
+            config: self.streamConfig,
+            rendererProvider: {
+                DrawableVideoDecoder(
+                    texture: self.texture,
+                    callbacks: self.connectionCallbacks,
+                    aspectRatio: Float(self.streamConfig.width) / Float(self.streamConfig.height),
+                    useFramePacing: self.streamConfig.useFramePacing,
+                    enableHDR: self.viewModel.streamSettings.enableHdr
+                ) { texture, correctedResultion in
+                    DispatchQueue.main.async {
+                        if let correctedResultion = correctedResultion {
+                            streamConfig.width = Int32(correctedResultion.0)
+                            streamConfig.height = Int32(correctedResultion.1)
+                        }
+                        self.texture.replace(withDrawables: texture)
+                        self.controllerSupport!.connectionEstablished()
+                        if self.curveAnimationMultiplier == 0 { animateOpening() }
+                    }
+                }
+            },
+            connectionCallbacks: self.connectionCallbacks
+        )
+        let operationQueue = OperationQueue()
+        operationQueue.addOperation(_streamMan!)
+        needsResume = false
+    }
+
+    private func pauseStreamForBackground() {
+        guard _streamMan != nil else { return }
+        stopStream(teardownCompletely: false)
+    }
+
+    private func handleUserRequestedClose() {
+        stopStream(teardownCompletely: true)
+        DispatchQueue.main.async {
+            openWindow(id: "mainView")
+        }
+        viewModel.realityWindowNeedsManualClose = true
+    }
+
+    private func stopStream(teardownCompletely: Bool) {
+        _streamMan?.stopStream()
+        _streamMan = nil
+        controllerSupport?.cleanup()
+
+        if teardownCompletely {
+            if didPerformFullClose {
+                return
+            }
+            didPerformFullClose = true
+            viewModel.activelyStreaming = false
+            needsResume = false
+            self.closeAction()
+        } else {
+            needsResume = true
+        }
+    }
+
+    private func handleSceneDisappearance() {
+        guard !didPerformFullClose else { return }
+        guard !needsResume else { return }
+        handleExternalWindowDismiss()
+    }
+
+    private func handleExternalWindowDismiss() {
+        stopStream(teardownCompletely: true)
+        DispatchQueue.main.async {
+            openWindow(id: "mainView")
+        }
+        viewModel.realityWindowNeedsManualClose = true
     }
 
     func animateOpening() {

--- a/Moonlight Vision/Resources/Localizable.strings
+++ b/Moonlight Vision/Resources/Localizable.strings
@@ -1,0 +1,2 @@
+// Localizable strings for Moonlight Vision
+"settings_title" = "Settings";

--- a/Moonlight Vision/SettingsView.swift
+++ b/Moonlight Vision/SettingsView.swift
@@ -11,16 +11,17 @@ import SwiftUI
 
 struct SettingsView: View {
     @Binding public var settings: TemporarySettings
+    @EnvironmentObject private var viewModel: MainViewModel
     @State private var selectedAspectRatio: AspectRatio?
     @State private var isCustomAspectRatio: Bool = false
 
     var body: some View {
         NavigationStack {
             Form {
-                Section(header: Text("Video settings")) {
+                Section(header: Text(viewModel.localized(english: "Video settings", chinese: "视频设置"))) {
                     NavigationLink {
                         Form {
-                            Picker("Resolution", selection: $settings.resolution) {
+                            Picker(viewModel.localized(english: "Resolution", chinese: "分辨率"), selection: $settings.resolution) {
                                 ForEach(Self.resolutionsGroupedByType, id: \.0) { aspectRatio, resolutions in
                                     ForEach(resolutions, id: \.self) { resolution in
                                         Text(resolution.description)
@@ -33,9 +34,9 @@ struct SettingsView: View {
                         }
                         .ornament(attachmentAnchor: .scene(.bottom)) {
                             HStack {
-                                TextField("Width", value: $settings.resolution.width, format: .number)
-                                Text("by")
-                                TextField("Height", value: $settings.resolution.height, format: .number)
+                                TextField(viewModel.localized(english: "Width", chinese: "宽度"), value: $settings.resolution.width, format: .number)
+                                Text(viewModel.localized(english: "by", chinese: "×"))
+                                TextField(viewModel.localized(english: "Height", chinese: "高度"), value: $settings.resolution.height, format: .number)
                             }
                             .textFieldStyle(.roundedBorder)
                             .keyboardType(.numberPad)
@@ -49,10 +50,10 @@ struct SettingsView: View {
                                 }
                             }
                         }
-                        .navigationTitle("Resolution")
+                        .navigationTitle(viewModel.localized(english: "Resolution", chinese: "分辨率"))
                     } label: {
                         HStack {
-                            Text("Resolution")
+                            Text(viewModel.localized(english: "Resolution", chinese: "分辨率"))
                             Spacer()
                             Text(settings.resolution.description)
                         }
@@ -60,7 +61,7 @@ struct SettingsView: View {
                     
                     NavigationLink {
                         Form {
-                            Picker("Aspect Ratio", selection: $selectedAspectRatio) {
+                            Picker(viewModel.localized(english: "Aspect Ratio", chinese: "宽高比"), selection: $selectedAspectRatio) {
                                 ForEach(Self.resolutionsGroupedByType.map { $0.0 }, id: \.self) { aspectRatio in
                                     Text(aspectRatio.casualDescription).tag(aspectRatio as AspectRatio?)
                                 }
@@ -72,7 +73,7 @@ struct SettingsView: View {
                                 if let selectedAspectRatio {
                                     Text(selectedAspectRatio.casualDescription)
                                 } else {
-                                    Text("Custom")
+                                    Text(viewModel.localized(english: "Custom", chinese: "自定义"))
                                 }
                             }
                             .textFieldStyle(.roundedBorder)
@@ -88,73 +89,97 @@ struct SettingsView: View {
                                 }
                             }
                         }
-                        .navigationTitle("Aspect Ratio")
+                        .navigationTitle(viewModel.localized(english: "Aspect Ratio", chinese: "宽高比"))
                     } label: {
                         HStack {
-                            Text("Aspect Ratio")
+                            Text(viewModel.localized(english: "Aspect Ratio", chinese: "宽高比"))
                             Spacer()
                             Text(settings.resolution.aspectRatio.casualDescription)
                         }
                     }
-                    Picker("Framerate", selection: $settings.framerate) {
+                    Picker(viewModel.localized(english: "Framerate", chinese: "帧率"), selection: $settings.framerate) {
                         ForEach(Self.framerateTable, id: \.self) { framerate in
                             Text("\(framerate)")
                         }
                     }
-                    Picker("Bitrate", selection: $settings.bitrate) {
+                    Picker(viewModel.localized(english: "Bitrate", chinese: "比特率"), selection: $settings.bitrate) {
                         ForEach(Self.bitrateTable, id: \.self) { bitrate in
                             Text("\(bitrate / 1000)Mbps")
                         }
                     }
                     
-                    Picker("Renderer", selection: $settings.renderer) {
-                        Text("UIKit (classic)").tag(Renderer.classic)
-                        Text("RealityKit (native)").tag(Renderer.realitykit)
+                    Picker(viewModel.localized(english: "Renderer", chinese: "渲染器"), selection: $settings.renderer) {
+                        Text(viewModel.localized(english: "UIKit (classic)", chinese: "UIKit（经典）")).tag(Renderer.classic)
+                        Text(viewModel.localized(english: "RealityKit (native)", chinese: "RealityKit（原生）")).tag(Renderer.realitykit)
                     }
                 }
                 if (settings.renderer == .realitykit) {
-                    Section(header: Text("RealityKit Renderer Settings (Experimental)"), footer: Text("The new RealityKit renderer is experemental and currently does not support keyboard or mouse, come at me on reddit u/tht7 if you care")) {
-                        Toggle("Animate screen curve", isOn: $settings.realitykitRendererAnimateOpening)
-                        Text("Screen curvature")
+                    Section(header: Text(viewModel.localized(english: "RealityKit Renderer Settings (Experimental)", chinese: "RealityKit 渲染器设置（实验性）")), footer: Text(viewModel.localized(english: "The new RealityKit renderer is experemental and currently does not support keyboard or mouse, come at me on reddit u/tht7 if you care", chinese: "新的 RealityKit 渲染器是实验性的，目前不支持键盘或鼠标，如有问题请在 Reddit 上联系 u/tht7"))) {
+                        Toggle(viewModel.localized(english: "Animate screen curve", chinese: "屏幕曲线动画"), isOn: $settings.realitykitRendererAnimateOpening)
+                        Text(viewModel.localized(english: "Screen curvature", chinese: "屏幕曲率"))
                         Slider(value: $settings.realitykitRendererCurvature, in: (0...1), step: 0.001)
                     }
                 } else {
-                    Section(header: Text("UIKit (Classic) Renderer Settings")) {
-                        Picker("Touch Mode", selection: $settings.absoluteTouchMode) {
-                            Text("Touchpad").tag(false)
-                            Text("Touchscreen").tag(true)
+                    Section(header: Text(viewModel.localized(english: "UIKit (Classic) Renderer Settings", chinese: "UIKit（经典）渲染器设置"))) {
+                        Picker(viewModel.localized(english: "Touch Mode", chinese: "触摸模式"), selection: $settings.absoluteTouchMode) {
+                            Text(viewModel.localized(english: "Touchpad", chinese: "触控板")).tag(false)
+                            Text(viewModel.localized(english: "Touchscreen", chinese: "触摸屏")).tag(true)
                         }
-                        Picker("On-Screen Controls", selection: $settings.onscreenControls) {
-                            Text("Off").tag(OnScreenControlsLevel.off)
-                            Text("Auto").tag(OnScreenControlsLevel.auto)
-                            Text("Simple").tag(OnScreenControlsLevel.simple)
-                            Text("Full").tag(OnScreenControlsLevel.full)
+                        Picker(viewModel.localized(english: "On-Screen Controls", chinese: "屏幕控制"), selection: $settings.onscreenControls) {
+                            Text(viewModel.localized(english: "Off", chinese: "关闭")).tag(OnScreenControlsLevel.off)
+                            Text(viewModel.localized(english: "Auto", chinese: "自动")).tag(OnScreenControlsLevel.auto)
+                            Text(viewModel.localized(english: "Simple", chinese: "简单")).tag(OnScreenControlsLevel.simple)
+                            Text(viewModel.localized(english: "Full", chinese: "完整")).tag(OnScreenControlsLevel.full)
                         }
-                        Toggle("Citrix X1 Mouse Support", isOn: $settings.btMouseSupport)
-                        Toggle("Statistics Overlay", isOn: $settings.statsOverlay)
+                        Toggle(viewModel.localized(english: "Citrix X1 Mouse Support", chinese: "Citrix X1 鼠标支持"), isOn: $settings.btMouseSupport)
+                        Toggle(viewModel.localized(english: "Statistics Overlay", chinese: "统计信息叠加"), isOn: $settings.statsOverlay)
                     }
                 }
-                Toggle("Optimize Game Settings", isOn: $settings.optimizeGames)
-                Picker("Multi-Controller Mode", selection: $settings.multiController) {
-                    Text("Single").tag(false)
-                    Text("Auto").tag(true)
+                Toggle(viewModel.localized(english: "Optimize Game Settings", chinese: "优化游戏设置"), isOn: $settings.optimizeGames)
+                Picker(viewModel.localized(english: "Multi-Controller Mode", chinese: "多控制器模式"), selection: $settings.multiController) {
+                    Text(viewModel.localized(english: "Single", chinese: "单个")).tag(false)
+                    Text(viewModel.localized(english: "Auto", chinese: "自动")).tag(true)
                 }
-                Toggle("Swap A/B and X/Y Buttons", isOn: $settings.swapABXYButtons)
-                Toggle("Play Audio on PC", isOn: $settings.playAudioOnPC)
-                Picker("Preferred Codec", selection: $settings.preferredCodec) {
+                Toggle(viewModel.localized(english: "Swap A/B and X/Y Buttons", chinese: "交换 A/B 和 X/Y 按钮"), isOn: $settings.swapABXYButtons)
+                Toggle(viewModel.localized(english: "Play Audio on PC", chinese: "在 PC 上播放音频"), isOn: $settings.playAudioOnPC)
+                Picker(viewModel.localized(english: "Audio Session Mode", chinese: "音频会话模式"), selection: $settings.audioSessionMode) {
+                    ForEach(Array(AudioSessionMode.allCases), id: \.self) { mode in
+                        Text(mode.localizedDisplayName(for: viewModel.currentLanguage)).tag(mode)
+                    }
+                }
+                Picker(viewModel.localized(english: "App Language", chinese: "应用语言"), selection: Binding(get: { settings.appLanguage }, set: { settings.appLanguage = $0 })) {
+                    ForEach(Array(AppLanguage.allCases), id: \.self) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                HStack {
+                    Text(viewModel.localized(english: "Window Corner Radius", chinese: "窗口圆角"))
+                    Spacer()
+                    Slider(value: $settings.windowCornerRadius, in: 0...60, step: 5) {
+                        Text(viewModel.localized(english: "Window Corner Radius", chinese: "窗口圆角"))
+                    }
+                    .frame(width: 200)
+                    Text("\(Int(settings.windowCornerRadius))")
+                }
+                if settings.windowCornerRadius > 0 {
+                    Text(viewModel.localized(english: "Note: Corner radius may slightly affect rendering sharpness. Set to 0 for maximum clarity.", chinese: "注意：圆角可能会略微影响渲染清晰度。设置为 0 可获得最佳清晰度。"))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Picker(viewModel.localized(english: "Preferred Codec", chinese: "首选编解码器"), selection: $settings.preferredCodec) {
                     Text("H.264").tag(PreferredCodec.h264)
                     Text("HEVC").tag(PreferredCodec.hevc)
                     Text("AV1").tag(PreferredCodec.av1)
-                    Text("Auto").tag(PreferredCodec.auto)
+                    Text(viewModel.localized(english: "Auto", chinese: "自动")).tag(PreferredCodec.auto)
                 }
-                Toggle("Enable HDR", isOn: $settings.enableHdr)
-                Picker("Frame Pacing", selection: $settings.useFramePacing) {
-                    Text("Lowest Latency").tag(false)
-                    Text("Smoothest Video").tag(true)
+                Toggle(viewModel.localized(english: "Enable HDR", chinese: "启用 HDR"), isOn: $settings.enableHdr)
+                Picker(viewModel.localized(english: "Frame Pacing", chinese: "帧节奏"), selection: $settings.useFramePacing) {
+                    Text(viewModel.localized(english: "Lowest Latency", chinese: "最低延迟")).tag(false)
+                    Text(viewModel.localized(english: "Smoothest Video", chinese: "最流畅视频")).tag(true)
                 }
-                Toggle("Automatically dim passthrough and hide window controls", isOn: $settings.dimPassthrough)
+                Toggle(viewModel.localized(english: "Automatically dim passthrough and hide window controls", chinese: "自动调暗穿透并隐藏窗口控制"), isOn: $settings.dimPassthrough)
             }
-            .navigationTitle("Settings")
+            .navigationTitle(viewModel.localized(english: "Settings", chinese: "设置"))
             .onDisappear {
                 settings.save()
             }

--- a/Moonlight Vision/StreamControls.swift
+++ b/Moonlight Vision/StreamControls.swift
@@ -40,17 +40,17 @@ struct StreamControls<Additions: View>: View {
     var controls: some View {
         Group {
             // --- START ADDITION ---
-            Button("Home", systemImage: "house.fill") {
+            Button(viewModel.localized(english: "Home", chinese: "主页"), systemImage: "house.fill") {
                // openWindow(id: "mainView")
                 closeAction() // Call the provided close action
             }
             // --- END ADDITION ---
             
-            Button("Toggle Dimming", systemImage: viewModel.streamSettings.dimPassthrough ? "moon.fill" : "moon") {
+            Button(viewModel.localized(english: "Toggle Dimming", chinese: "切换调暗"), systemImage: viewModel.streamSettings.dimPassthrough ? "moon.fill" : "moon") {
                 viewModel.streamSettings.dimPassthrough.toggle()
             }
             HStack {
-                Button("Volume", systemImage: viewModel.vol == 0 || viewModel.mute ? "speaker.slash.fill" : "speaker.fill" ) {
+                Button(viewModel.localized(english: "Volume", chinese: "音量"), systemImage: viewModel.vol == 0 || viewModel.mute ? "speaker.slash.fill" : "speaker.fill" ) {
                     viewModel.mute.toggle()
                 }
                 Slider(value: $viewModel.vol, in: 0...127)

--- a/Moonlight Vision/UIKitStreamView.swift
+++ b/Moonlight Vision/UIKitStreamView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct UIKitStreamView: View {
     @Binding var streamConfig: StreamConfiguration?
@@ -14,66 +15,156 @@ struct UIKitStreamView: View {
     @EnvironmentObject private var viewModel: MainViewModel
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
+    @Environment(\.scenePhase) private var scenePhase
 
-    // This state tracks if *we* triggered the close.
-    @State private var isClosingForHome = false
+    @State private var hasPerformedTeardown = false
+    @State private var needsResume = false
+    @State private var reloadToken = UUID()
+    @State private var backgroundTask: Task<Void, Never>?
 
     var body: some View {
-        if let configBinding = Binding($streamConfig) {
-            _UIKitStreamView(streamConfig: configBinding)
-                .ornament(attachmentAnchor: .scene(.top), contentAlignment: .bottom) {
-                    StreamControls(
-                        horizontal: true,
-                        streamConfig: configBinding,
-                        // This action just disconnects the stream
-                        // and opens the main menu.
-                        closeAction: {
-                            // 1. Tell the app we are no longer streaming.
-                            viewModel.activelyStreaming = false
-                            
-                            // 2. Open the main view.
-                            openWindow(id: "mainView")
-                            
-                            // 3. Find the view controller and tell it to stop.
-                            if let streamVC = _UIKitStreamView.controllerReference.object {
-                                streamVC.stopStream()
+        Group {
+            if viewModel.activelyStreaming,
+               let configBinding = Binding($streamConfig) {
+                let cornerRadius = CGFloat(viewModel.streamSettings.windowCornerRadius)
+                _UIKitStreamView(streamConfig: configBinding)
+                    .id(reloadToken)
+                    .compositingGroup()
+                    .applyCornerRadius(cornerRadius)
+                    .ornament(attachmentAnchor: .scene(.top), contentAlignment: .bottom) {
+                        StreamControls(
+                            horizontal: true,
+                            streamConfig: configBinding,
+                            closeAction: {
+                                handleHomeButtonClose()
                             }
-                            
-                            // 4. We DO NOT set streamConfig = nil.
+                        ) {
+                            _UIKitStreamViewWindowButton(
+                                streamConfig: configBinding,
+                                controllerReference: _UIKitStreamView.controllerReference
+                            )
                         }
-                    ) {
-                        _UIKitStreamViewWindowButton(streamConfig: configBinding, controllerReference: _UIKitStreamView.controllerReference)
                     }
-                }
-                .onAppear {
-                    // This is the "resume from sleep" fix
-                    if !viewModel.activelyStreaming {
-                        print("UIKitStreamView: Detected appearance without active stream state...")
-                        
-                        isClosingForHome = true // Act as if home was pressed
-                        openWindow(id: "mainView")
-                        streamConfig = nil
-                        dismissWindow(id: "classicStreamingWindow")
-                    } else {
-                        // This is a normal stream start
-                        isClosingForHome = false // Ensure flag is reset
+                    .onAppear {
+                        hasPerformedTeardown = false
                         dismissWindow(id: "mainView")
                     }
-                }
-        } else {
-            // This 'else' block is rendered when streamConfig becomes nil.
-            // Its .onAppear acts as the .onDisappear for the stream view.
-            EmptyView()
-                .onAppear {
-                    // Check if we got here by pressing the Home button.
-                    if isClosingForHome {
-                        // Safely open the main view *after* this window is gone.
-                        openWindow(id: "mainView")
+                    .onDisappear {
+                        handleWindowDisappearance()
                     }
-                    
-                    // Always make sure this window is dismissed.
-                    dismissWindow(id: "classicStreamingWindow")
+                    .onChange(of: scenePhase) { _, phase in
+                        switch phase {
+                        case .background:
+                            // Only pause when truly backgrounded (e.g., immersive scene or headset removal)
+                            // Don't pause on .inactive as it triggers too easily when switching apps
+                            prepareForBackground()
+                        case .active:
+                            resumeIfNeeded()
+                        default:
+                            break
+                        }
+                    }
+            } else {
+                VStack(spacing: 16) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.largeTitle)
+                    Text(viewModel.localized(english: "Stream stopped", chinese: "串流已停止"))
+                        .font(.title2)
+                    Text(viewModel.localized(english: "Please close this window before starting a new stream from the main menu.", chinese: "在返回主菜单前请先关闭此窗口，之后即可在主菜单重新启动串流。"))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.thinMaterial)
+                .onAppear {
+                    viewModel.classicWindowNeedsManualClose = true
+                }
+                .onDisappear {
+                    viewModel.classicWindowNeedsManualClose = false
+                }
+            }
+        }
+    }
+
+    private func handleHomeButtonClose() {
+        tearDownStream(openMainWindow: true)
+    }
+
+    private func handleWindowDisappearance() {
+        guard !hasPerformedTeardown else { return }
+        guard !needsResume else { return }
+        tearDownStream(openMainWindow: true)
+    }
+
+    private func tearDownStream(openMainWindow: Bool) {
+        guard !hasPerformedTeardown else { return }
+        hasPerformedTeardown = true
+        needsResume = false
+
+        viewModel.activelyStreaming = false
+
+        if let streamVC = _UIKitStreamView.controllerReference.object {
+            streamVC.stopStream()
+        }
+
+        streamConfig = nil
+        if openMainWindow {
+            DispatchQueue.main.async {
+                openWindow(id: "mainView")
+            }
+        }
+        
+        viewModel.classicWindowNeedsManualClose = true
+    }
+
+    private func prepareForBackground() {
+        guard !hasPerformedTeardown else { return }
+        guard streamConfig != nil else { return }
+        
+        // Save current window size before backgrounding
+        saveCurrentWindowSize()
+        
+        // Cancel any pending background task
+        backgroundTask?.cancel()
+        
+        // Set needsResume flag
+        needsResume = true
+        
+        // Stop the stream
+        if let streamVC = _UIKitStreamView.controllerReference.object {
+            streamVC.stopStream()
+        }
+    }
+    
+    private func saveCurrentWindowSize() {
+        // Try to find the window and save its size
+        if let streamVC = _UIKitStreamView.controllerReference.object,
+           let window = streamVC.view.window ?? streamVC.view?.superview?.window {
+            let currentSize = window.bounds.size
+            viewModel.savedStreamWindowSize = currentSize
+            print("Saved window size before backgrounding: \(currentSize)")
+        }
+    }
+
+    private func resumeIfNeeded() {
+        guard needsResume else { return }
+        guard streamConfig != nil else { return }
+        
+        // Cancel any pending background task
+        backgroundTask?.cancel()
+        
+        // Only resume if we were actually backgrounded (not just briefly inactive)
+        // Add a small delay to ensure we're truly back from background
+        backgroundTask = Task {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 second delay
+            
+            guard !Task.isCancelled else { return }
+            guard needsResume else { return }
+            
+            await MainActor.run {
+                needsResume = false
+                reloadToken = UUID()
+            }
         }
     }
 }
@@ -86,8 +177,10 @@ struct _UIKitStreamViewWindowButton: View {
     var body: some View {
         Button {
             if let window = currentWindow {
-                applyAspectRatioLock(streamConfig: streamConfig, targetWindow: window) // Pass the window
-                AudioHelpers.fixAudioForSurroundForUIKitWindow(window) // TODO(shinyquagsire23): Make this configurable
+                // When manually triggered, don't use saved size - recalculate
+                applyAspectRatioLock(streamConfig: streamConfig, targetWindow: window, useSavedSize: false)
+                let exclusive = MainViewModel.shouldUseExclusiveAudio(microphoneActive: false)
+                AudioHelpers.fixAudioForSurroundForUIKitWindow(window, exclusive: exclusive) // TODO(shinyquagsire23): Make this configurable
             } else {
                 print("Error: No window reference available to apply aspect ratio lock.")
                 // Optionally provide user feedback here, e.g., an alert
@@ -130,7 +223,8 @@ struct _UIKitStreamViewWindowButton: View {
                     if let window = viewToFindWindow?.window {
                         print("Found window by traversing view hierarchy: \(window)")
                         currentWindow = window
-                        AudioHelpers.fixAudioForSurroundForUIKitWindow(window)
+                        let exclusive = MainViewModel.shouldUseExclusiveAudio(microphoneActive: false)
+                        AudioHelpers.fixAudioForSurroundForUIKitWindow(window, exclusive: exclusive)
                         return
                     }
                     viewToFindWindow = viewToFindWindow?.superview
@@ -163,9 +257,18 @@ struct _UIKitStreamView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewControllerType {
         let streamView = StreamFrameViewController()
         streamView.streamConfig = streamConfig
-        streamView.connectedCallback = {
+        streamView.connectedCallback = { [weak streamView] in
             print("Connected in Swift!")
-            AudioHelpers.fixAudioForSurroundForCurrentWindow() // TODO(shinyquagsire23): Make this configurable
+            let exclusive = MainViewModel.shouldUseExclusiveAudio(microphoneActive: false)
+            AudioHelpers.fixAudioForSurroundForCurrentWindow(exclusive: exclusive) // TODO(shinyquagsire23): Make this configurable
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                guard
+                    let window = streamView?.view.window ?? streamView?.view?.superview?.window
+                else {
+                    return
+                }
+                applyAspectRatioLock(streamConfig: streamConfig, targetWindow: window)
+            }
         };
         streamView.disconnectedCallback = {
             print("Disconnected in Swift!")
@@ -184,9 +287,25 @@ class Reference<T: AnyObject> {
     weak var object: T?
 }
 
+// MARK: - View Modifiers
+
+extension View {
+    @ViewBuilder
+    func applyCornerRadius(_ radius: CGFloat) -> some View {
+        if radius > 0 {
+            // Use compositingGroup to optimize rendering, then clipShape
+            // This approach minimizes the impact on rendering quality
+            self.clipShape(RoundedRectangle(cornerRadius: radius))
+        } else {
+            self
+        }
+    }
+}
+
 // MARK: - Helper Functions
 
-func applyAspectRatioLock(streamConfig: StreamConfiguration, targetWindow: UIWindow?) {
+@MainActor
+func applyAspectRatioLock(streamConfig: StreamConfiguration, targetWindow: UIWindow?, useSavedSize: Bool = true) {
     guard let window = targetWindow else {
         print("Error: No target window provided to apply aspect ratio lock.")
         return
@@ -198,18 +317,40 @@ func applyAspectRatioLock(streamConfig: StreamConfiguration, targetWindow: UIWin
 
     print("Applying Aspect Ratio Lock - Stream Width: \(streamWidth), Stream Height: \(streamHeight), Stream AR: \(streamAspectRatio)")
 
-    let maxWidth: CGFloat = 2000 // Increased maxWidth for potentially larger screens
     var desiredSize = CGSize.zero
+    
+    // If we have a saved window size and useSavedSize is true, use it
+    if useSavedSize, let savedSize = MainViewModel.shared.savedStreamWindowSize {
+        // Verify the saved size maintains the correct aspect ratio (within tolerance)
+        let savedAspectRatio = savedSize.width / savedSize.height
+        let aspectRatioDifference = abs(savedAspectRatio - streamAspectRatio) / streamAspectRatio
+        
+        // If aspect ratio is close enough (within 5% tolerance), use saved size
+        if aspectRatioDifference < 0.05 {
+            desiredSize = savedSize
+            print("Using saved window size: \(savedSize)")
+            // Clear saved size after using it
+            MainViewModel.shared.savedStreamWindowSize = nil
+        } else {
+            print("Saved size aspect ratio mismatch, recalculating. Saved AR: \(savedAspectRatio), Stream AR: \(streamAspectRatio)")
+            // Fall through to calculate new size
+        }
+    }
+    
+    // If we don't have a saved size or it doesn't match, calculate new size
+    if desiredSize == .zero {
+        let maxWidth: CGFloat = 2000 // Increased maxWidth for potentially larger screens
+        
+        for desiredWidthInt in (1...Int(maxWidth)).reversed() {
+            let desiredWidth = CGFloat(desiredWidthInt)
+            let desiredHeightFloat = desiredWidth / streamAspectRatio
+            let desiredHeightInt = Int(round(desiredHeightFloat))
 
-    for desiredWidthInt in (1...Int(maxWidth)).reversed() {
-        let desiredWidth = CGFloat(desiredWidthInt)
-        let desiredHeightFloat = desiredWidth / streamAspectRatio
-        let desiredHeightInt = Int(round(desiredHeightFloat))
-
-        if desiredHeightInt > 0 {
-            desiredSize = CGSize(width: desiredWidth, height: CGFloat(desiredHeightInt))
-            //print("Calculated Desired Size - Width: \(desiredSize.width), Height: \(desiredSize.height)")
-            break
+            if desiredHeightInt > 0 {
+                desiredSize = CGSize(width: desiredWidth, height: CGFloat(desiredHeightInt))
+                //print("Calculated Desired Size - Width: \(desiredSize.width), Height: \(desiredSize.height)")
+                break
+            }
         }
     }
 

--- a/Moonlight Vision/UpdatesView.swift
+++ b/Moonlight Vision/UpdatesView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct UpdatesView: View {
+    @EnvironmentObject private var viewModel: MainViewModel
+    
     var body: some View {
         GeometryReader { geometry in // 1. GeometryReader to get screen width
             let screenWidth = geometry.size.width
@@ -20,7 +22,7 @@ struct UpdatesView: View {
                 Section { // Section for the title (no header)
                     HStack { // 2. HStack to apply padding to title
                         Spacer() // Push title to center if needed
-                        Text("Changelog")
+                        Text(viewModel.localized(english: "Changelog", chinese: "更新日志"))
                             .font(.largeTitle)
                             .multilineTextAlignment(.center) // Ensure title text is centered within its area
                         Spacer() // Push title to center if needed
@@ -31,7 +33,7 @@ struct UpdatesView: View {
                 .listRowBackground(Color.clear) // Remove background from this section
 
 
-                Section(header: Text("Latest Updates")) { // Section for latest updates
+                Section(header: Text(viewModel.localized(english: "Latest Updates", chinese: "最新更新"))) { // Section for latest updates
                     VStack(alignment: .leading) { // Original VStack for text alignment
                         Text("Version 11.0.11 (Oct 25, 2025)")
                             .font(.headline)
@@ -148,7 +150,7 @@ struct UpdatesView: View {
                     .frame(maxWidth: .infinity, alignment: .leading) // Ensure VStack takes full width and aligns content to leading
                 }
 
-                Section(header: Text("Noted Bugs")) { // Section for older updates
+                Section(header: Text(viewModel.localized(english: "Noted Bugs", chinese: "已知问题"))) { // Section for older updates
                     VStack(alignment: .leading) {
                         Text("- If you get a blackscreen trying to resume a volume, this has to do with resumption, I am trying to figure out a better alert system for when this happens. Just force quit the app.")
                             .font(.body)
@@ -171,7 +173,7 @@ struct UpdatesView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 
-                Section(header: Text("Feature Requests")) { // Section for older updates
+                Section(header: Text(viewModel.localized(english: "Feature Requests", chinese: "功能请求"))) { // Section for older updates
                     VStack(alignment: .leading) {
                         Text("- Virtual Keyboard Button.")
                             .font(.body)
@@ -191,9 +193,9 @@ struct UpdatesView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                Section(header: Text("More Information")) { // Optional section for more links etc.
+                Section(header: Text(viewModel.localized(english: "More Information", chinese: "更多信息"))) { // Optional section for more links etc.
                     VStack(alignment: .leading) {
-                        Text("Official Website:")
+                        Text(viewModel.localized(english: "Official Website:", chinese: "官方网站："))
                             .font(.body)
                         Link("Moonlight Game Streaming Project Website", destination: URL(string: "https://moonlight-stream.org/")!)
                             .font(.body)

--- a/Moonlight iOS/ViewControllers/StreamFrameViewController.m
+++ b/Moonlight iOS/ViewControllers/StreamFrameViewController.m
@@ -149,7 +149,8 @@
     _stageLabel = [[UILabel alloc] init];
     [self.view addSubview:_stageLabel];
     [_stageLabel setUserInteractionEnabled:NO];
-    [_stageLabel setText:[NSString stringWithFormat:@"Starting %@...", self.streamConfig.appName]];
+    NSString *formatString = [MainViewModel startingStreamFormatString];
+    [_stageLabel setText:[NSString stringWithFormat:formatString, self.streamConfig.appName]];
     [_stageLabel sizeToFit];
     _stageLabel.textAlignment = NSTextAlignmentCenter;
     _stageLabel.textColor = [UIColor whiteColor];

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -226,6 +226,8 @@
 		FBD349621A0089F6002D2A60 /* DataManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FBD349611A0089F6002D2A60 /* DataManager.m */; };
 		FBDE86E019F7A837001C18A8 /* UIComputerView.m in Sources */ = {isa = PBXBuildFile; fileRef = FBDE86DF19F7A837001C18A8 /* UIComputerView.m */; };
 		FBDE86E619F82297001C18A8 /* UIAppView.m in Sources */ = {isa = PBXBuildFile; fileRef = FBDE86E519F82297001C18A8 /* UIAppView.m */; };
+		F7C8B2022D60B40000A1A1A1 /* LanguagePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7C8B2012D60B40000A1A1A1 /* LanguagePromptView.swift */; };
+
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -537,6 +539,8 @@
 		FBDE86DF19F7A837001C18A8 /* UIComputerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIComputerView.m; sourceTree = "<group>"; };
 		FBDE86E419F82297001C18A8 /* UIAppView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIAppView.h; sourceTree = "<group>"; };
 		FBDE86E519F82297001C18A8 /* UIAppView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIAppView.m; sourceTree = "<group>"; };
+		F7C8B2012D60B40000A1A1A1 /* LanguagePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguagePromptView.swift; sourceTree = "<group>"; };
+
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -673,6 +677,7 @@
 				F7A4A4D02B5F216C001591F3 /* MainViewModel.swift */,
 				F778956D2B65975900F02568 /* SDLMainWrapper.m */,
 				F778956F2B65979500F02568 /* SDLMainWrapper.h */,
+				F7C8B2012D60B40000A1A1A1 /* LanguagePromptView.swift */,
 			);
 			path = "Moonlight Vision";
 			sourceTree = "<group>";
@@ -1303,6 +1308,7 @@
 				F7A1191A2B5DDF73001E8686 /* mkcert.c in Sources */,
 				B1EDB13D2D4D95BF00EB1839 /* StreamConfiguration.swift in Sources */,
 				F77B58B22B5EFC9000482BD5 /* ComputerView.swift in Sources */,
+				F7C8B2022D60B40000A1A1A1 /* LanguagePromptView.swift in Sources */,
 				F7199AFB2B72F33000E6D62D /* SettingsView.swift in Sources */,
 				F7A1191B2B5DDF73001E8686 /* HttpResponse.m in Sources */,
 				F718014A2B655C1F00A9336B /* Utils.swift in Sources */,
@@ -1510,7 +1516,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 2423V7K2Y5;
+				DEVELOPMENT_TEAM = UHY653Z667;
 				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Limelight/Limelight-Prefix.pch";
@@ -1558,7 +1564,7 @@
 				);
 				MARKETING_VERSION = 11.0.11;
 				OTHER_LDFLAGS = "-ld64";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.moonlight-stream-beta.Moonlight-Vision-luma";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.moonlight-stream-beta.Moonlight-Vision-lingganua";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = xros;
@@ -1587,7 +1593,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 2423V7K2Y5;
+				DEVELOPMENT_TEAM = UHY653Z667;
 				ENABLE_MODULE_VERIFIER = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Limelight/Limelight-Prefix.pch";
@@ -1635,7 +1641,7 @@
 				);
 				MARKETING_VERSION = 11.0.11;
 				OTHER_LDFLAGS = "-ld64";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.moonlight-stream-beta.Moonlight-Vision-luma";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.moonlight-stream-beta.Moonlight-Vision-lingganua";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = xros;


### PR DESCRIPTION
# Changelog - Moonlight Vision Pro Improvements

# 更新日志 - Moonlight Vision Pro 改进

## Bug Fixes / 错误修复

### Fixed Black Screen Recovery Issue / 修复黑屏恢复问题
- **RealityKit Mode**: Fixed stream window turning black after returning from background or immersive scenes. Stream now properly resumes when the window becomes active again.
- **UIKit Mode**: Applied the same black screen recovery fix to UIKit streaming mode. Stream properly resumes after backgrounding or closing/reopening the app.
- **RealityKit 模式**: 修复了从后台或沉浸式场景返回后串流窗口变黑的问题。窗口重新激活时串流现在可以正常恢复。
- **UIKit 模式**: 将相同的黑屏恢复修复应用到 UIKit 串流模式。后台运行或关闭/重新打开应用后串流可以正常恢复。

### Fixed Window Lifecycle Management / 修复窗口生命周期管理
- **Home Button Handling**: Fixed crashes and orphaned windows when pressing the Home button during streaming. Windows now properly pause the stream instead of crashing.
- **Window Dismissal**: Improved window dismissal logic to prevent residual window bars and unresponsive states. Implemented user-driven manual window closure with clear instructions.
- **Background/Resume**: Properly handle app backgrounding and resumption. Streams pause when backgrounded and resume when the app becomes active again.
- **Home 按钮处理**: 修复了串流期间按下 Home 按钮时的崩溃和残留窗口问题。窗口现在会正确暂停串流而不是崩溃。
- **窗口关闭**: 改进了窗口关闭逻辑，防止残留窗口横条和无响应状态。实现了用户驱动的窗口手动关闭，并提供清晰的说明。
- **后台/恢复**: 正确处理应用后台化和恢复。应用进入后台时串流暂停，应用重新激活时恢复。

### Fixed Stream Conflict Handling / 修复串流冲突处理
- **Duplicate Stream Prevention**: Added detection for active stream windows. When attempting to start a new stream while an old one is still open, users are prompted with options: return to existing window, force quit old stream, or cancel.
- **Manual Window Closure**: Old stream windows display a clear message asking users to manually close them before starting a new stream. This prevents multiple stream windows and app crashes.
- **状态检测**: 添加了活动串流窗口的检测。当尝试启动新串流而旧窗口仍打开时，用户会收到提示：返回现有窗口、强制结束旧串流或取消。
- **手动窗口关闭**: 旧串流窗口显示清晰消息，要求用户手动关闭后再启动新串流。这防止了多个串流窗口和应用崩溃。

## New Features / 新功能

### Audio Session Management / 音频会话管理
- **Three Audio Modes**: Added three configurable audio session modes in Settings:
  - **Microphone Exclusive (Default)**: Traditional exclusive audio session that mutes other system media
  - **Allow Mixing with Other Audio**: Allows Moonlight audio to mix with other apps' audio
  - **Exclusive Only When Microphone Active**: Only uses exclusive mode when microphone is active, allowing mixing otherwise
- **三种音频模式**: 在设置中添加了三种可配置的音频会话模式：
  - **麦克风独占（默认）**: 传统的独占音频会话，会静音其他系统媒体
  - **允许与其他音频混音**: 允许 Moonlight 音频与其他应用的音频混音
  - **仅在使用麦克风时才切换到独占模式**: 仅在麦克风激活时使用独占模式，其他时候允许混音

### Window Corner Radius Customization / 窗口圆角自定义
- Added a slider in Settings to adjust the corner radius of streaming windows (both UIKit and RealityKit modes)
- Range: 0-60 pixels, default: 0 pixels (for maximum clarity)
- **Note**: Corner radius may slightly affect rendering sharpness. Default is set to 0 for maximum clarity.
- **窗口圆角调整**: 在设置中添加了滑块来调整串流窗口的圆角（UIKit 和 RealityKit 模式均支持）
- **范围**: 0-60 像素，默认：0 像素（以获得最佳清晰度）
- **注意**: 圆角可能会略微影响渲染清晰度。默认设置为 0 以获得最佳清晰度。

### Language Selection / 语言选择
- **First Launch Prompt**: Added a language selection prompt on first app launch, allowing users to choose between English and Simplified Chinese
- **Settings Integration**: Added language picker in Settings menu for changing language at any time
- **Persistent Storage**: Language preference is saved and persists across app restarts
- **首次启动提示**: 在首次启动应用时添加了语言选择提示，允许用户在英文和简体中文之间选择
- **设置集成**: 在设置菜单中添加了语言选择器，可随时更改语言
- **持久化存储**: 语言偏好设置会被保存，并在应用重启后保持

### Comprehensive Localization / 全面本地化
- **Complete UI Translation**: All user-facing text in the app now supports both English and Simplified Chinese:
  - Main menu and navigation
  - Settings and preferences
  - Error messages and alerts
  - Stream controls and status messages
  - Pairing and connection prompts
  - Window close instructions
- **Dynamic Language Switching**: Language changes take effect immediately without requiring app restart
- **完整界面翻译**: 应用中所有面向用户的文本现在都支持英文和简体中文：
  - 主菜单和导航
  - 设置和偏好
  - 错误消息和提示
  - 串流控制和状态消息
  - 配对和连接提示
  - 窗口关闭说明
- **动态语言切换**: 语言更改立即生效，无需重启应用

### Aspect Ratio Lock / 宽高比锁定
- **UIKit Mode**: Automatically applies aspect ratio lock when stream starts, eliminating the need for manual button presses to avoid black bars when resizing windows
- **UIKit 模式**: 串流启动时自动应用宽高比锁定，无需手动按按钮即可避免调整窗口大小时出现黑边

## Technical Improvements / 技术改进

### Code Organization / 代码组织
- Refactored stream lifecycle management into separate methods for better maintainability
- Improved state management with proper `@State` and `@Published` properties
- Added helper methods for audio session configuration and language localization
- **代码重构**: 将串流生命周期管理重构为独立方法，提高可维护性
- **状态管理**: 使用适当的 `@State` 和 `@Published` 属性改进状态管理
- **辅助方法**: 添加了音频会话配置和语言本地化的辅助方法

### Error Handling / 错误处理
- Improved error messages with localized text
- Better handling of edge cases in window lifecycle
- More robust stream state management
- **错误处理改进**: 使用本地化文本改进错误消息
- **边缘情况处理**: 更好地处理窗口生命周期中的边缘情况
- **状态管理**: 更健壮的串流状态管理

## Files Modified / 修改的文件

### Swift Files / Swift 文件
- `Moonlight Vision/MainViewModel.swift` - Added language management, audio session helpers, stream conflict detection
- `Moonlight Vision/MainContentView.swift` - Added language prompt, improved window dismissal logic
- `Moonlight Vision/RealityKitStreamView.swift` - Fixed black screen recovery, added manual close prompt, corner radius support
- `Moonlight Vision/UIKitStreamView.swift` - Fixed black screen recovery, added aspect ratio auto-lock, manual close prompt
- `Moonlight Vision/AppsView.swift` - Added stream conflict detection and alerts
- `Moonlight Vision/SettingsView.swift` - Added audio session mode picker, corner radius slider, language picker
- `Moonlight Vision/ComputerView.swift` - Localized all user-facing text
- `Moonlight Vision/StreamControls.swift` - Localized control buttons
- `Moonlight Vision/UpdatesView.swift` - Localized section headers
- `Moonlight Vision/LanguagePromptView.swift` - New file for first-launch language selection
- `Limelight/TemporarySettings.swift` - Added audio session mode enum, window corner radius, app language settings

### Objective-C Files / Objective-C 文件
- `Moonlight iOS/ViewControllers/StreamFrameViewController.m` - Localized "Starting..." message

### Project Files / 项目文件
- `Moonlight.xcodeproj/project.pbxproj` - Added LanguagePromptView.swift to project

## Testing Recommendations / 测试建议

1. **Black Screen Recovery**: Test by backgrounding the app, entering immersive scenes, and closing/reopening windows
2. **Stream Conflicts**: Test by starting a stream, pressing Home, then attempting to start another stream
3. **Audio Modes**: Test each audio session mode with system media playing
4. **Language Switching**: Test switching languages in Settings and verify all text updates
5. **Corner Radius**: Test adjusting corner radius with active streams
6. **Window Lifecycle**: Test various scenarios: Home button, app backgrounding, window dismissal

## 测试建议

1. **黑屏恢复**: 通过后台化应用、进入沉浸式场景、关闭/重新打开窗口进行测试
2. **串流冲突**: 通过启动串流、按 Home 键、然后尝试启动另一个串流进行测试
3. **音频模式**: 在系统媒体播放时测试每种音频会话模式
4. **语言切换**: 在设置中测试切换语言并验证所有文本更新
5. **圆角调整**: 在活动串流时测试调整圆角
6. **窗口生命周期**: 测试各种场景：Home 按钮、应用后台化、窗口关闭

## Notes for Maintainers / 维护者注意事项

- All new features are backward compatible
- Language preference defaults to English if not set
- Audio session mode defaults to exclusive (existing behavior)
- Window corner radius defaults to 0 pixels (for maximum clarity)
- **Important**: Window corner radius implementation uses `.clipShape()` which may slightly affect rendering sharpness. This is a limitation of SwiftUI/UIKit rendering system（maybe？）. Users can set it to 0 for maximum clarity.
- All localization uses a helper method pattern for consistency

## 维护者注意事项

- 所有新功能都向后兼容
- 如果未设置，语言偏好默认为英文
- 音频会话模式默认为独占（现有行为）
- 窗口圆角默认 0 像素（以获得最佳清晰度）
- **重要**: 窗口圆角实现使用 `.clipShape()`，可能会略微影响渲染清晰度。这是 SwiftUI/UIKit 渲染系统的限制。（可能是？）用户可将其设置为 0 以获得最佳清晰度。
- 所有本地化使用辅助方法模式以保持一致性

