### PR TITLE
Add low-latency streaming entitlement to avoid AWDL interference

### DIFF
--- a/Moonlight Vision/Moonlight XrOS.entitlements
+++ b/Moonlight Vision/Moonlight XrOS.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.low-latency-streaming</key>
+	<true/>
+</dict>
+</plist>

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		F7A1195A2B5DE1E2001E8686 /* MoonlightVisionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonlightVisionApp.swift; sourceTree = "<group>"; };
 		F7A1195C2B5DE1FD001E8686 /* MainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContentView.swift; sourceTree = "<group>"; };
 		F7A119EF2B5DE2EA001E8686 /* Moonlight copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Moonlight copy-Info.plist"; path = "/Users/ahaugland/Documents/github/moonlight-ios/Moonlight copy-Info.plist"; sourceTree = "<absolute>"; };
+		5A6A9F003097481892490686 /* Moonlight XrOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Moonlight XrOS.entitlements"; sourceTree = "<group>"; };
 		F7A119FF2B5DF387001E8686 /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
 		F7A11A1D2B5DF457001E8686 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/XROS.platform/Developer/SDKs/XROS1.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		F7A11A1F2B5DF46B001E8686 /* RealityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealityKit.framework; path = Platforms/XROS.platform/Developer/SDKs/XROS1.0.sdk/System/Library/Frameworks/RealityKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -673,6 +674,7 @@
 				F7A4A4D02B5F216C001591F3 /* MainViewModel.swift */,
 				F778956D2B65975900F02568 /* SDLMainWrapper.m */,
 				F778956F2B65979500F02568 /* SDLMainWrapper.h */,
+				5A6A9F003097481892490686 /* Moonlight XrOS.entitlements */,
 			);
 			path = "Moonlight Vision";
 			sourceTree = "<group>";
@@ -1506,6 +1508,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Moonlight Vision/Moonlight XrOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
@@ -1583,6 +1586,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "Moonlight Vision/Moonlight XrOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ The Vision OS Version is not available in the App Store, to download the latest 
     * In reality kit mode, use the rectangle button toggle above the height adjust
 * How do I use Ultrawide Mode?
     * In settings set the resolution to 5120x1440, then set up [Apollo](https://github.com/ClassicOldSong/Apollo) or a virtual display driver / dumy plug and set the same settings on windows. In UIKit you can then use the aspect ratio button to fix the black bars, it should just be automatic on Reality Kit Mode. If you already connected with the wrong settings, you have to STOP the stream by long pressing the 'Virtual Display App' and start the stream again to apply the new settings.
-* Why is my connection so choppy?
-    * AWDL (apple wireless direct) is a special feature on apple devices that enable features like AirDrop and Handoff. Unforutenatly this can cause stutters at high bit rates, you can try turning off AirDrop and Continuity features, but it is best to use a 5ghz router with it set to use wifi Ch 149 
 * How do I use a wired connection?
     * You can use a developer strap hooked up to a mac with ethernet and then some additional ifconfig commands
     * Alternatively you can do something with a [Rapsberry Pi](https://x.com/ShinyQuagsire/status/1766286564408394186)
@@ -124,8 +122,6 @@ Thanks again for your support :)
     * In reality kit mode, use the rectangle button toggle above the height adjust
 * How do I use Ultrawide Mode?
     * In settings set the resolution to 5120x1440, then set up [Apollo](https://github.com/ClassicOldSong/Apollo) or a virtual display driver / dumy plug and set the same settings on windows. In UIKit you can then use the aspect ratio button to fix the black bars, it should just be automatic on Reality Kit Mode. If you already connected with the wrong settings, you have to STOP the stream by long pressing the 'Virtual Display App' and start the stream again to apply the new settings.
-* Why is my connection so choppy?
-    * AWDL (apple wireless direct) is a special feature on apple devices that enable features like AirDrop and Handoff. Unforutenatly this can cause stutters at high bit rates, you can try turning off AirDrop and Continuity features, but it is best to use a 5ghz router with it set to use wifi Ch 149 
 * How do I use a wired connection?
     * You can use a developer strap hooked up to a mac with ethernet and then some additional ifconfig commands
     * Alternatively you can do something with a [Rapsberry Pi](https://x.com/ShinyQuagsire/status/1766286564408394186)


### PR DESCRIPTION
## Summary

This PR adds the `com.apple.developer.low-latency-streaming` entitlement to Moonlight XrOS to avoid wireless interference from AWDL.  Inspired by ALVR's latest release that has gotten positive feedback from its users.

## What is this entitlement?

The low-latency streaming entitlement is a visionOS feature that prioritizes streaming traffic and prevents AWDL from interfering with the video stream. This addresses a common issue where features like AirDrop and Handoff can cause stuttering at high bitrates.

## Changes

- Created `Moonlight Vision/Moonlight XrOS.entitlements` with the low-latency streaming entitlement
- Updated Xcode project configuration to reference the entitlements file in both Debug and Release builds
- Updated README to reflect that the app now uses this entitlement, removing outdated workaround advice

## Developer Notes

I'm not familiar with Xcode development so please critique before merging.  Also, I'm unsure if you need to request the entitlement to match this app for TestFlight.

I asked Claude and it said the following:

```
This entitlement requires approval from Apple for use in production. To request it:
1. Go to https://developer.apple.com/contact/request/
2. Select "Request an entitlement"
3. Explain the use case (game streaming app for Vision Pro)

The app will build and run fine without approval, but the entitlement won't take effect until it's been approved and added to your provisioning profile.
```

## Testing

I haven't tested this myself.  When I open up Xcode I get the error

```
Personal development teams, including "...", do not support the Low-Latency Streaming capability.
```

But I do see the new entitlement appear in the signing and capabilities tab.

<img width="1018" height="318" alt="CleanShot 2025-11-15 at 13 51 04@2x" src="https://github.com/user-attachments/assets/038b65be-2ccf-4bfa-b894-66a15a88e651" />

Overall I took what I saw in ALVR and ported it over here as best I could.