### PR TITLE
Add stats overlay toggle to UIKit

### DIFF
--- a/Moonlight Vision/StreamControls.swift
+++ b/Moonlight Vision/StreamControls.swift
@@ -14,28 +14,34 @@ struct StreamControls<Additions: View>: View {
     
     let horizontal: Bool
     @Binding var streamConfig: StreamConfiguration
-    
+
     let isKeyboardActive: Bool
+    let isStatsOverlayActive: Bool
     let closeAction: () -> Void
     let toggleKeyboardAction: (() -> Void)?
+    let toggleStatsAction: (() -> Void)?
 
     @State private var spatialAudioMode: Bool = true // From Razorub
     @State private var volumeBeforeMute: Float = 127
-    
+
     @ViewBuilder var additions: () -> Additions
     
     // Initializer
     init(horizontal: Bool,
          streamConfig: Binding<StreamConfiguration>,
          isKeyboardActive: Bool = false,
+         isStatsOverlayActive: Bool = false,
          closeAction: @escaping () -> Void,
          toggleKeyboardAction: (() -> Void)? = nil,
+         toggleStatsAction: (() -> Void)? = nil,
          @ViewBuilder additions: @escaping () -> Additions) {
         self.horizontal = horizontal
         self._streamConfig = streamConfig
         self.isKeyboardActive = isKeyboardActive
+        self.isStatsOverlayActive = isStatsOverlayActive
         self.closeAction = closeAction
         self.toggleKeyboardAction = toggleKeyboardAction
+        self.toggleStatsAction = toggleStatsAction
         self.additions = additions
     }
 
@@ -81,7 +87,16 @@ struct StreamControls<Additions: View>: View {
                 Text(spatialAudioMode ? viewModel.localized("spatial_audio") : viewModel.localized("direct_audio"))
             }
             // -------------------------------------
-            
+
+            // Stats Overlay Toggle
+            if let toggleAction = toggleStatsAction {
+                Button(action: toggleAction) {
+                    Text(viewModel.localized("statistics_overlay"))
+                }
+                .background(isStatsOverlayActive ? Color.white.opacity(0.2) : Color.clear)
+                .clipShape(Capsule())
+            }
+
             // Virtual Keyboard Toggle
             if let toggleAction = toggleKeyboardAction {
                 Button(action: toggleAction) {

--- a/Moonlight Vision/UIKitStreamView.swift
+++ b/Moonlight Vision/UIKitStreamView.swift
@@ -22,18 +22,20 @@ struct UIKitStreamView: View {
     @State private var backgroundTask: Task<Void, Never>?
     @State private var windowSizeMonitorTask: Task<Void, Never>? = nil
     @State private var lastSavedWindowSize: CGSize? = nil
+    @State private var statsOverlayText: String = ""
 
     var body: some View {
         Group {
             if viewModel.activelyStreaming,
                let configBinding = Binding($streamConfig) {
-                _UIKitStreamView(streamConfig: configBinding)
+                _UIKitStreamView(streamConfig: configBinding, statsOverlayText: $statsOverlayText)
                     .id(reloadToken)
                     .ornament(attachmentAnchor: .scene(.top), contentAlignment: .bottom) {
                         StreamControls(
                             horizontal: true,
                             streamConfig: configBinding,
                             isKeyboardActive: false,
+                            isStatsOverlayActive: viewModel.streamSettings.statsOverlay,
                             closeAction: {
                                 handleHomeButtonClose()
                             },
@@ -41,10 +43,25 @@ struct UIKitStreamView: View {
                                 if let streamVC = _UIKitStreamView.controllerReference.object {
                                     streamVC.toggleKeyboard()
                                 }
+                            },
+                            toggleStatsAction: {
+                                viewModel.streamSettings.statsOverlay.toggle()
+                                viewModel.streamSettings.save()
+
+                                if let streamVC = _UIKitStreamView.controllerReference.object {
+                                    streamVC.toggleStatsOverlay()
+                                }
                             }
                         ) {
                             _UIKitStreamViewWindowButton(streamConfig: configBinding, controllerReference: _UIKitStreamView.controllerReference)
                         }
+                    }
+                    .ornament(
+                        visibility: viewModel.streamSettings.statsOverlay ? .visible : .hidden,
+                        attachmentAnchor: .scene(.topTrailing),
+                        contentAlignment: .topLeading
+                    ) {
+                        StatsOverlayView(statsText: statsOverlayText)
                     }
                     .onAppear {
                         hasPerformedTeardown = false
@@ -345,10 +362,23 @@ struct _UIKitStreamView: UIViewControllerRepresentable {
     typealias UIViewControllerType = StreamFrameViewController
 
     @Binding var streamConfig: StreamConfiguration
+    @Binding var statsOverlayText: String
     static let controllerReference = Reference<UIViewControllerType>()
 
     static var reference: Reference<UIViewControllerType> {
         return controllerReference
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(statsOverlayText: $statsOverlayText)
+    }
+
+    class Coordinator {
+        var statsOverlayText: Binding<String>
+
+        init(statsOverlayText: Binding<String>) {
+            self.statsOverlayText = statsOverlayText
+        }
     }
 
     func makeUIViewController(context: Context) -> UIViewControllerType {
@@ -366,6 +396,11 @@ struct _UIKitStreamView: UIViewControllerRepresentable {
         };
         streamView.disconnectedCallback = {
             print("Disconnected in Swift!")
+        };
+        streamView.statsUpdateCallback = { [weak coordinator = context.coordinator] statsText in
+            DispatchQueue.main.async {
+                coordinator?.statsOverlayText.wrappedValue = statsText ?? ""
+            }
         };
         _UIKitStreamView.controllerReference.object = streamView
         return streamView
@@ -441,4 +476,17 @@ func applyAspectRatioLock(streamConfig: StreamConfiguration, targetWindow: UIWin
     )
 
     windowScene.requestGeometryUpdate(geometryRequest)
+}
+
+struct StatsOverlayView: View {
+    let statsText: String
+
+    var body: some View {
+        Text(statsText)
+            .font(.system(size: 12, design: .monospaced))
+            .foregroundColor(.gray)
+            .padding(8)
+            .background(.black.opacity(0.7))
+            .cornerRadius(4)
+    }
 }

--- a/Moonlight iOS/ViewControllers/StreamFrameViewController.h
+++ b/Moonlight iOS/ViewControllers/StreamFrameViewController.h
@@ -23,9 +23,11 @@
 typedef void (^noargCallbackType)(void);
 @property (nonatomic, strong) noargCallbackType connectedCallback;
 @property (nonatomic, strong) noargCallbackType disconnectedCallback;
+@property (nonatomic, strong) void (^statsUpdateCallback)(NSString* statsText);
 
 -(void)updatePreferredDisplayMode:(BOOL)streamActive;
 - (void)stopStream;
-- (void)toggleKeyboard; // <-- ADD THIS
+- (void)toggleKeyboard;
+- (void)toggleStatsOverlay;
 
 @end

--- a/Moonlight iOS/ViewControllers/StreamFrameViewController.m
+++ b/Moonlight iOS/ViewControllers/StreamFrameViewController.m
@@ -320,9 +320,9 @@
 - (void)updateStatsOverlay {
     NSString* overlayText = [self->_streamMan getStatsOverlayText];
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self updateOverlayText:overlayText];
-    });
+    if (self.statsUpdateCallback) {
+        self.statsUpdateCallback(overlayText);
+    }
 }
 
 - (void)updateOverlayText:(NSString*)text {
@@ -449,6 +449,7 @@
                                                                      selector:@selector(updateStatsOverlay)
                                                                      userInfo:nil
                                                                       repeats:YES];
+            [self updateStatsOverlay];
         }
         
         if (self->_connectedCallback) {
@@ -783,6 +784,35 @@
 
 - (void)toggleKeyboard {
     [_streamView toggleKeyboard];
+}
+
+- (void)toggleStatsOverlay {
+    // Toggle the setting
+    _settings.statsOverlay = !_settings.statsOverlay;
+    [_settings save];
+
+    if (_settings.statsOverlay) {
+        // Start the stats timer
+        if (_statsUpdateTimer == nil) {
+            _statsUpdateTimer = [NSTimer scheduledTimerWithTimeInterval:1.0f
+                                                                 target:self
+                                                               selector:@selector(updateStatsOverlay)
+                                                               userInfo:nil
+                                                                repeats:YES];
+            // Update immediately
+            [self updateStatsOverlay];
+        }
+    } else {
+        // Stop the stats timer
+        if (_statsUpdateTimer != nil) {
+            [_statsUpdateTimer invalidate];
+            _statsUpdateTimer = nil;
+        }
+        // Clear the overlay
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self updateOverlayText:@""];
+        });
+    }
 }
 
 


### PR DESCRIPTION
This PR adds a new toggle in the UIKit render for displaying / hiding statistical overlay.  Two enhancements:

1. The statistical overlay no longer blocks the stream feed
2. The overlay can be toggled on and off as needed without reverting back home to change settings

It also respects what setting was originally selected in settings before starting the stream.

![CleanShot 2025-11-28 at 10 06 49](https://github.com/user-attachments/assets/1c63df05-902f-4b42-ad04-44fd506fb77d)
