### PR TITLE
Fix AV1 HDR: PQ/HLG tagging in the AV1 parser, isPQ hardening, FFmpeg-free UIKit AV1

### DIFF
--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -9,6 +9,7 @@
 #import "VideoDecoderRenderer.h"
 #import "StreamView.h"
 #import "NSData+Conversion.h"
+#import "Moonlight-Swift.h"
 
 #include <libavcodec/avcodec.h>
 #include <libavcodec/cbs.h>
@@ -515,9 +516,22 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
         }
         else if (videoFormat & VIDEO_FORMAT_MASK_AV1) {
             NSData* fullFrameData = [NSData dataWithBytesNoCopy:data length:length freeWhenDone:NO];
-            
+
             Log(LOG_I, @"Constructing new AV1 format description");
-            formatDesc = [self createAV1FormatDescriptionForIDRFrame:fullFrameData];
+            // Prefer the FFmpeg-free Swift parser: the bundled FFmpeg libs may lack
+            // CONFIG_CBS_AV1, in which case ff_cbs_init() fails with EINVAL on every
+            // IDR frame and the stream never starts. FFmpeg remains the fallback.
+            CMVideoFormatDescriptionRef swiftDesc =
+                [AV1FormatDescriptionBridge formatDescriptionFromIDRFrame:fullFrameData
+                                             masteringDisplayColorVolume:masteringDisplayColorVolume
+                                                   contentLightLevelInfo:contentLightLevelInfo];
+            if (swiftDesc != NULL) {
+                formatDesc = (CMVideoFormatDescriptionRef)CFRetain(swiftDesc);
+            }
+            else {
+                Log(LOG_W, @"Swift AV1 parser failed, falling back to FFmpeg");
+                formatDesc = [self createAV1FormatDescriptionForIDRFrame:fullFrameData];
+            }
         }
         else {
             // Unsupported codec!

--- a/Moonlight Vision/AV1Parser.swift
+++ b/Moonlight Vision/AV1Parser.swift
@@ -149,6 +149,11 @@ public func CMVideoFormatDescriptionCreateFromAV1SequenceHeaderOBUWithAV1C(_ obu
         TC_BT_709 : kCVImageBufferTransferFunction_ITU_R_709_2,
         TC_BT_2020_10_BIT : kCVImageBufferTransferFunction_ITU_R_2020,
         TC_BT_2020_12_BIT : kCVImageBufferTransferFunction_ITU_R_2020,
+        // HDR transfer functions. Without these, a PQ (ST.2084) AV1 stream falls through to the
+        // ITU_R_709_2 default below, VideoToolbox tags the decoded buffers as SDR, and
+        // DrawableVideoDecoder never sets isPQ — so the PQ curve is never applied and HDR is lost.
+        TC_SMPTE_2084 : kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ,
+        TC_HLG : kCVImageBufferTransferFunction_ITU_R_2100_HLG,
         TC_BT_601 : kCVImageBufferTransferFunction_sRGB,
         TC_SRGB : kCVImageBufferTransferFunction_sRGB,
     ]

--- a/Moonlight Vision/AV1Parser.swift
+++ b/Moonlight Vision/AV1Parser.swift
@@ -637,3 +637,51 @@ extension UnsafeMutableBufferPointer {
         return UnsafeMutableBufferPointer(start: start, count: count)
     }
 }
+
+// MARK: - Objective-C bridge for the UIKit video path
+
+/// Exposes this parser to VideoDecoderRenderer.m. The UIKit path historically built its AV1
+/// CMVideoFormatDescription through FFmpeg's coded bitstream reader; FFmpeg libraries built
+/// without CONFIG_CBS_AV1 make ff_cbs_init() fail with EINVAL on every IDR frame, leaving the
+/// stream stuck requesting IDRs forever. This parser has no FFmpeg dependency.
+@objc(AV1FormatDescriptionBridge)
+public class AV1FormatDescriptionBridge: NSObject {
+
+    /// Named without a create/copy prefix so the generated ObjC interface is
+    /// cf_returns_not_retained: the ObjC caller must CFRetain if it stores the result.
+    @objc public static func formatDescription(
+        fromIDRFrame frameData: Data,
+        masteringDisplayColorVolume mdcv: Data?,
+        contentLightLevelInfo clli: Data?
+    ) -> CMFormatDescription? {
+        var mutable = frameData
+        let baseDesc: CMFormatDescription? = mutable.withUnsafeMutableBytes { raw in
+            let typed = raw.bindMemory(to: UInt8.self)
+            let buffer = UnsafeMutableBufferPointer(start: typed.baseAddress, count: typed.count)
+            return try? CMVideoFormatDescriptionCreateFromAV1SequenceHeaderOBUWithAV1C(buffer)
+        }
+        guard let desc = baseDesc else { return nil }
+        guard mdcv != nil || clli != nil else { return desc }
+
+        let extensions = ((CMFormatDescriptionGetExtensions(desc) as NSDictionary?)?
+            .mutableCopy() as? NSMutableDictionary) ?? NSMutableDictionary()
+        if let mdcv {
+            extensions[kCMFormatDescriptionExtension_MasteringDisplayColorVolume as NSString] = mdcv as NSData
+        }
+        if let clli {
+            extensions[kCMFormatDescriptionExtension_ContentLightLevelInfo as NSString] = clli as NSData
+        }
+
+        let dimensions = CMVideoFormatDescriptionGetDimensions(desc)
+        var enriched: CMFormatDescription?
+        let status = CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: kCMVideoCodecType_AV1,
+            width: dimensions.width,
+            height: dimensions.height,
+            extensions: extensions as CFDictionary,
+            formatDescriptionOut: &enriched
+        )
+        return status == noErr ? (enriched ?? desc) : desc
+    }
+}

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -267,6 +267,14 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
             isPQ = looksLikeBt2020TenBitStream
         }
 
+        // Safety net for streams whose transfer function is mis-tagged as SDR upstream of us.
+        // Gated on the *negotiated* 10-bit format, so 8-bit SDR streams in HDR mode still take
+        // the SDR path and never get decoded through pqInv().
+        if !isPQ && hdrEnabled && looksLikeBt2020TenBitStream
+            && (videoFormat & VIDEO_FORMAT_MASK_10BIT) != 0 {
+            isPQ = true
+        }
+
         var primariesType: UInt32 = 0 // 0=709, 1=2020, 2=SMPTE-C(601)
         if let primVal = CVBufferGetAttachment(imageBuffer, kCVImageBufferColorPrimariesKey, nil)?.takeUnretainedValue(),
            CFGetTypeID(primVal) == CFStringGetTypeID() {


### PR DESCRIPTION
Three related fixes to AV1 format descriptions and HDR tagging. Tested on Apple Vision Pro M5 (visionOS 27 beta, build 24M5326g) against an Apollo v0.4.6 host, AV1 Main10 3840x2160 and 5120x2160 @ 90-120 fps, 200 Mbps.

## 1. AV1 HDR was silently decoded as SDR (RealityKit path)

`tcMap` in `CMVideoFormatDescriptionCreateFromAV1SequenceHeaderOBUWithAV1C` (AV1Parser.swift) has no entry for `TC_SMPTE_2084` (16) or `TC_HLG` (18), so a PQ AV1 sequence header falls through to the `ITU_R_709_2` default. VideoToolbox copies that attachment onto every decoded pixel buffer, `DrawableVideoDecoder` reads it and leaves `isPQ = false` (the attachment *exists*, it is just wrong, so the `hdrEnabled` fallback never fires), and `Shaders.metal` runs its SDR branch on PQ-encoded samples - washed out, flat, no highlights. HEVC Main10 was unaffected because `makeDefaultColorExtensions(for: .hevc)` forces PQ explicitly, which masked this bug.

Device log, same stream, before then after:
```
[DrawableVideoDecoder] PF=420YpCbCr10BiPlanarVideoRange, planes=2, hdr=true, PQ=false, ...
[DrawableVideoDecoder] PF=420YpCbCr10BiPlanarVideoRange, planes=2, hdr=true, PQ=true, fullRange=false, primariesType=1, matrixType=1
```

## 2. Harden isPQ against mistagged streams

Belt-and-braces companion: if HDR is enabled, the decoded buffer is 10-bit BT.2020 **and** a 10-bit format was actually negotiated with the host, treat the frame as PQ even when the transfer-function attachment claims otherwise. Gating on `VIDEO_FORMAT_MASK_10BIT` keeps 8-bit SDR streams in HDR mode on the SDR path, so this does not reintroduce the "SDR through pqInv()" regression the comment above it guards against.

## 3. UIKit mode AV1 spins forever on the current FFmpeg binaries

The UIKit path builds its AV1 `CMVideoFormatDescription` through FFmpeg's coded bitstream reader. The FFmpeg static libs updated in fb34983 are built without `CONFIG_CBS_AV1`, so `ff_cbs_init()` fails with `AVERROR(EINVAL)` on every IDR frame and the stream requests IDRs in an endless loop (infinite spinner):
```
<INFO> Constructing new AV1 format description
<ERROR> ff_cbs_init() failed: -22
```
(repeats ~20x/second)

The pure-Swift AV1 parser already used by the RealityKit path has no FFmpeg dependency. This exposes it to Objective-C via a small `AV1FormatDescriptionBridge` (appended to AV1Parser.swift) and uses it first in `VideoDecoderRenderer.m`, keeping FFmpeg as a fallback. Fix #1 also makes the resulting descriptions carry the right PQ transfer function. Verified: UIKit AV1 HDR streams start normally and reach the panel's full HDR range.

Each commit is independent and cherry-pickable. Files touched: `Moonlight Vision/AV1Parser.swift`, `Moonlight Vision/DrawableVideoDecoder.swift`, `Limelight/Stream/VideoDecoderRenderer.m`.

Note: on fresh installs, seeing HDR at all also needs the zeroed-color-settings fix (#23) - the two bugs masked each other.

🤖 Coded with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)