### PR TITLE
Treat zeroed HDR color settings as unset (fresh installs rendered HDR as black)

### DIFF
--- a/Limelight/TemporarySettings.swift
+++ b/Limelight/TemporarySettings.swift
@@ -204,9 +204,17 @@ public class TemporarySettings: NSObject {
             self.macVirtualDisplayExperimental = UserDefaults.standard.bool(forKey: "macVirtualDisplayExperimental")
             
             // --- HDR / COLOR LOADING ---
-            self.brightness = settings.brightness?.floatValue ?? 1.0
-            self.gamma = settings.gamma?.floatValue ?? 1.0
-            self.saturation = settings.saturation?.floatValue ?? 1.0
+            // The Core Data model defaults these attributes to 0.0, so on a fresh install the
+            // stored NSNumber is 0.0 (not nil) and the `?? 1.0` fallback never fires. All three
+            // are multiplicative factors in the HDR shader: boost=0 renders pure black,
+            // saturation=0 greyscale, contrast=0 flat. Treat 0 as "unset" and use neutral 1.0.
+            func neutralIfUnset(_ value: NSNumber?) -> Float {
+                let f = value?.floatValue ?? 1.0
+                return f == 0.0 ? 1.0 : f
+            }
+            self.brightness = neutralIfUnset(settings.brightness)
+            self.gamma = neutralIfUnset(settings.gamma)
+            self.saturation = neutralIfUnset(settings.saturation)
             self.pqExposure = 1.0
             
             if let storedLang = UserDefaults.standard.object(forKey: appLanguageDefaultsKey) as? Int {


### PR DESCRIPTION
## Problem

On a fresh install, enabling HDR gives a **pure black screen** in RealityKit mode (SDR works fine). Users who happened to touch the color sliders at some point never see it - which makes it look like random breakage.

## Root cause

The Core Data model defaults `brightness`, `gamma` and `saturation` to `0.0`. On first launch the stored `NSNumber` is therefore `0.0`, **not nil**, so the loading code's `?? 1.0` fallback never fires:
```swift
self.brightness = settings.brightness?.floatValue ?? 1.0   // loads 0.0
```
All three are multiplicative factors in the HDR shader path: `boost = 0` gives a black screen, `saturation = 0` greyscale, `contrast = 0` a flat image. The UI slider itself has `range: 0.5...3.0, defaultValue: 1.0`, so `0` is not even a value a user can legitimately set.

This stayed hidden until now because the AV1 PQ tagging bug (#21) prevented the PQ shader branch from ever running on AV1 streams - the two bugs masked each other.

## Fix

Treat `0` as "unset" when loading and substitute the neutral `1.0`. This also heals existing installs that already have `0.0` persisted. (A follow-up could change the `.xcdatamodel` defaults, but that alone would not fix existing databases.)

## Verification

Apple Vision Pro M5 (visionOS 27 beta, 24M5326g), Apollo v0.4.6, fresh install: HDR black screen before; correct PQ image after. Moving the brightness slider mid-stream on an unpatched build also instantly restores the image, confirming the mechanism.

🤖 Coded with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)