### PR TITLE
Volume mode: keep the screen and its panels inside the clipping bounds (soft-lock fix)

### DIFF
--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -2260,12 +2260,32 @@ struct _RealityKitStreamView: View {
         let screenHalfHeight = (CURVED_MAX_WIDTH_METERS * screenAspect * scaleFactor) / 2
         let volHalfHeight = volSize.y / 2
         let safePadding: Float = 0.05
-        let maxY = max(0, volHalfHeight - screenHalfHeight - safePadding)
+        // The hide/controls bar hangs 0.08 (screen-local) above the screen's top edge
+        // and the stats card 0.07 below the bottom edge; leave room for them so they
+        // are never clipped by the volume bounds at max height.
+        let attachmentClearance: Float = 0.15 * scaleFactor
+        let maxY = max(0, volHalfHeight - screenHalfHeight - attachmentClearance - safePadding)
         let newYLimits: ClosedRange<Float> = -maxY...maxY
         let volHalfDepth = volSize.z / 2
-        let maxZ = volHalfDepth - safePadding
-        let scaledCurveDepth = curveDepth * scaleFactor
-        let minZ = -volHalfDepth + scaledCurveDepth + safePadding
+        // Exact forward bulge of the curved mesh. Its vertices span z ∈ [0, sagitta]
+        // (edges bow toward the viewer): sagitta = R(1 - cos(angle/2)) with
+        // R = width/angle. The `curveDepth` estimate passed in scales with the screen
+        // *height*, which badly underestimates the bulge for wide aspect ratios.
+        let curveAngle = CURVED_MAX_ANGLE * max(0.0, min(effectiveCurvature, 2.0))
+        let sagitta: Float = curveAngle < 0.0001
+            ? 0
+            : (CURVED_MAX_WIDTH_METERS / curveAngle) * (1 - cos(curveAngle / 2))
+        let scaledSagitta = sagitta * scaleFactor
+        // Matches the zCorrection applied at placement time (screen.position).
+        let zCorrection = curveDepth * scaleFactor * 0.5
+        // The control panel is a child of the screen 0.22 (screen-local) in front of
+        // its origin. Whatever protrudes furthest — panel or curved edges — must stay
+        // inside the volume's front face: visionOS clips anything outside the bounds,
+        // and a clipped control panel is a soft-lock, since the only UI that could
+        // pull the screen back is itself invisible.
+        let frontExtent = max(0.22 * scaleFactor, scaledSagitta)
+        let maxZ = volHalfDepth - safePadding - zCorrection - frontExtent
+        let minZ = -volHalfDepth + safePadding - zCorrection
         let safeMaxZ = max(minZ, maxZ)
         let newZLimits: ClosedRange<Float> = minZ...safeMaxZ
         // Use epsilon comparison to avoid @State writes on every RealityView.update call


### PR DESCRIPTION
## Problem

In volume mode, pushing depth toward the front with curvature set (e.g. curvature 1.0, depth ~0.65) clips part of the curved screen and the control panel at the volume bounds. Since the panel is the only UI able to pull the screen back, the user is soft-locked - the state persists via "Remember Stream Settings" and survives restarts. Max height similarly pushes the hide/controls bar through the top face.

## Root cause

Three things extend past the screen origin and get clipped by visionOS at the volume bounds, none of which the depth/height limits accounted for:

- the curved mesh bulges toward the viewer by its exact sagitta `R * (1 - cos(angle/2))` with `R = width/angle` - the previous `curveDepth` estimate scales with the screen *height*, which badly underestimates the bulge for wide aspect ratios (measured 2.5x too small for 21:9);
- the control panel is parented 0.22 (screen-local) in front of the screen origin;
- the hide/controls bar sits 0.08 above the top edge (stats card 0.07 below).

## Fix

Account for the exact sagitta, the panel clearance and the attachment clearance in `updateVolumeWindowLimits`. The existing deferred clamp then self-heals previously saved out-of-range offsets on the next update pass - no user action needed to escape an existing soft-lock.

## Verification

Apple Vision Pro M5 (visionOS 27 beta, 24M5326g), Apollo v0.4.6. Reproduced the soft-lock on 16:9 and 21:9 (3840x1600, 5120x2160) streams; after the fix, saved out-of-bounds states are re-clamped on launch and the panel stays visible at max depth/height/curvature.

🤖 Coded with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)