### PR TITLE
RealityKit mode: true HDR (measured ~2600 nits) via VideoMaterial + AVSampleBufferVideoRenderer

### DIFF
--- a/Limelight/Stream/VideoDecoderRenderer.m
+++ b/Limelight/Stream/VideoDecoderRenderer.m
@@ -9,6 +9,7 @@
 #import "VideoDecoderRenderer.h"
 #import "StreamView.h"
 #import "NSData+Conversion.h"
+#import "Moonlight-Swift.h"
 
 #include <libavcodec/avcodec.h>
 #include <libavcodec/cbs.h>
@@ -515,9 +516,22 @@ int DrSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
         }
         else if (videoFormat & VIDEO_FORMAT_MASK_AV1) {
             NSData* fullFrameData = [NSData dataWithBytesNoCopy:data length:length freeWhenDone:NO];
-            
+
             Log(LOG_I, @"Constructing new AV1 format description");
-            formatDesc = [self createAV1FormatDescriptionForIDRFrame:fullFrameData];
+            // Prefer the FFmpeg-free Swift parser: the bundled FFmpeg libs may lack
+            // CONFIG_CBS_AV1, in which case ff_cbs_init() fails with EINVAL on every
+            // IDR frame and the stream never starts. FFmpeg remains the fallback.
+            CMVideoFormatDescriptionRef swiftDesc =
+                [AV1FormatDescriptionBridge formatDescriptionFromIDRFrame:fullFrameData
+                                             masteringDisplayColorVolume:masteringDisplayColorVolume
+                                                   contentLightLevelInfo:contentLightLevelInfo];
+            if (swiftDesc != NULL) {
+                formatDesc = (CMVideoFormatDescriptionRef)CFRetain(swiftDesc);
+            }
+            else {
+                Log(LOG_W, @"Swift AV1 parser failed, falling back to FFmpeg");
+                formatDesc = [self createAV1FormatDescriptionForIDRFrame:fullFrameData];
+            }
         }
         else {
             // Unsupported codec!

--- a/Limelight/TemporarySettings.swift
+++ b/Limelight/TemporarySettings.swift
@@ -55,6 +55,9 @@ public class TemporarySettings: NSObject {
     @objc public var realitykitScreenCornerRadius: Float = 0.018
     @objc public var realitykitImmersiveMode: Bool = false
     @objc public var reactiveLightingEnabled: Bool = false
+    /// RealityKit mode: render through AVSampleBufferVideoRenderer + VideoMaterial (system pipeline, true HDR/EDR)
+    /// instead of the Metal texture path (custom shaders, but compositor-clamped to ~1.2x SDR).
+    @objc public var useSystemVideoRenderer: Bool = true
 
     @objc public var gazeTouchMode = false
     @objc public var gazeCursorOffsetX: Int = 0
@@ -110,6 +113,7 @@ public class TemporarySettings: NSObject {
         self.dimPassthrough = false
         self.macVirtualDisplayExperimental = false
         self.reactiveLightingEnabled = false
+        self.useSystemVideoRenderer = true
         
         // HDR defaults: 1.0 = neutral (correct for shader)
         self.brightness = 1.0
@@ -201,6 +205,7 @@ public class TemporarySettings: NSObject {
             
             self.realitykitImmersiveMode = UserDefaults.standard.bool(forKey: "realitykitImmersiveMode")
             self.reactiveLightingEnabled = UserDefaults.standard.bool(forKey: "reactiveLightingEnabled")
+            self.useSystemVideoRenderer = UserDefaults.standard.object(forKey: "useSystemVideoRenderer") as? Bool ?? true
             self.macVirtualDisplayExperimental = UserDefaults.standard.bool(forKey: "macVirtualDisplayExperimental")
             
             // --- HDR / COLOR LOADING ---
@@ -234,6 +239,7 @@ public class TemporarySettings: NSObject {
     @objc public func save() {
         UserDefaults.standard.set(self.realitykitImmersiveMode, forKey: "realitykitImmersiveMode")
         UserDefaults.standard.set(self.reactiveLightingEnabled, forKey: "reactiveLightingEnabled")
+        UserDefaults.standard.set(self.useSystemVideoRenderer, forKey: "useSystemVideoRenderer")
         UserDefaults.standard.set(self.macVirtualDisplayExperimental, forKey: "macVirtualDisplayExperimental")
         UserDefaults.standard.set(self.autoResumeStreamOnReopen, forKey: "autoResumeStreamOnReopen")
         UserDefaults.standard.set(self.fpsMouseCapture, forKey: "fpsMouseCapture")
@@ -342,6 +348,7 @@ public class TemporarySettings: NSObject {
         self.realitykitScreenCornerRadius = 0.018
         self.realitykitImmersiveMode = false
         self.reactiveLightingEnabled = false
+        self.useSystemVideoRenderer = true
         self.macVirtualDisplayExperimental = false
         
         // Stream settings

--- a/Moonlight Vision/AV1Parser.swift
+++ b/Moonlight Vision/AV1Parser.swift
@@ -149,6 +149,11 @@ public func CMVideoFormatDescriptionCreateFromAV1SequenceHeaderOBUWithAV1C(_ obu
         TC_BT_709 : kCVImageBufferTransferFunction_ITU_R_709_2,
         TC_BT_2020_10_BIT : kCVImageBufferTransferFunction_ITU_R_2020,
         TC_BT_2020_12_BIT : kCVImageBufferTransferFunction_ITU_R_2020,
+        // HDR transfer functions. Without these, a PQ (ST.2084) AV1 stream falls through to the
+        // ITU_R_709_2 default below, VideoToolbox tags the decoded buffers as SDR, and
+        // DrawableVideoDecoder never sets isPQ — so the PQ curve is never applied and HDR is lost.
+        TC_SMPTE_2084 : kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ,
+        TC_HLG : kCVImageBufferTransferFunction_ITU_R_2100_HLG,
         TC_BT_601 : kCVImageBufferTransferFunction_sRGB,
         TC_SRGB : kCVImageBufferTransferFunction_sRGB,
     ]

--- a/Moonlight Vision/AV1Parser.swift
+++ b/Moonlight Vision/AV1Parser.swift
@@ -637,3 +637,51 @@ extension UnsafeMutableBufferPointer {
         return UnsafeMutableBufferPointer(start: start, count: count)
     }
 }
+
+// MARK: - Objective-C bridge for the UIKit video path
+
+/// Exposes this parser to VideoDecoderRenderer.m. The UIKit path historically built its AV1
+/// CMVideoFormatDescription through FFmpeg's coded bitstream reader; FFmpeg libraries built
+/// without CONFIG_CBS_AV1 make ff_cbs_init() fail with EINVAL on every IDR frame, leaving the
+/// stream stuck requesting IDRs forever. This parser has no FFmpeg dependency.
+@objc(AV1FormatDescriptionBridge)
+public class AV1FormatDescriptionBridge: NSObject {
+
+    /// Named without a create/copy prefix so the generated ObjC interface is
+    /// cf_returns_not_retained: the ObjC caller must CFRetain if it stores the result.
+    @objc public static func formatDescription(
+        fromIDRFrame frameData: Data,
+        masteringDisplayColorVolume mdcv: Data?,
+        contentLightLevelInfo clli: Data?
+    ) -> CMFormatDescription? {
+        var mutable = frameData
+        let baseDesc: CMFormatDescription? = mutable.withUnsafeMutableBytes { raw in
+            let typed = raw.bindMemory(to: UInt8.self)
+            let buffer = UnsafeMutableBufferPointer(start: typed.baseAddress, count: typed.count)
+            return try? CMVideoFormatDescriptionCreateFromAV1SequenceHeaderOBUWithAV1C(buffer)
+        }
+        guard let desc = baseDesc else { return nil }
+        guard mdcv != nil || clli != nil else { return desc }
+
+        let extensions = ((CMFormatDescriptionGetExtensions(desc) as NSDictionary?)?
+            .mutableCopy() as? NSMutableDictionary) ?? NSMutableDictionary()
+        if let mdcv {
+            extensions[kCMFormatDescriptionExtension_MasteringDisplayColorVolume as NSString] = mdcv as NSData
+        }
+        if let clli {
+            extensions[kCMFormatDescriptionExtension_ContentLightLevelInfo as NSString] = clli as NSData
+        }
+
+        let dimensions = CMVideoFormatDescriptionGetDimensions(desc)
+        var enriched: CMFormatDescription?
+        let status = CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: kCMVideoCodecType_AV1,
+            width: dimensions.width,
+            height: dimensions.height,
+            extensions: extensions as CFDictionary,
+            formatDescriptionOut: &enriched
+        )
+        return status == noErr ? (enriched ?? desc) : desc
+    }
+}

--- a/Moonlight Vision/DrawableVideoDecoder.swift
+++ b/Moonlight Vision/DrawableVideoDecoder.swift
@@ -267,6 +267,14 @@ class DrawableVideoDecoder: NSObject, AnyVideoDecoderRenderer {
             isPQ = looksLikeBt2020TenBitStream
         }
 
+        // Safety net for streams whose transfer function is mis-tagged as SDR upstream of us.
+        // Gated on the *negotiated* 10-bit format, so 8-bit SDR streams in HDR mode still take
+        // the SDR path and never get decoded through pqInv().
+        if !isPQ && hdrEnabled && looksLikeBt2020TenBitStream
+            && (videoFormat & VIDEO_FORMAT_MASK_10BIT) != 0 {
+            isPQ = true
+        }
+
         var primariesType: UInt32 = 0 // 0=709, 1=2020, 2=SMPTE-C(601)
         if let primVal = CVBufferGetAttachment(imageBuffer, kCVImageBufferColorPrimariesKey, nil)?.takeUnretainedValue(),
            CFGetTypeID(primVal) == CFStringGetTypeID() {

--- a/Moonlight Vision/MoonlightVisionApp.swift
+++ b/Moonlight Vision/MoonlightVisionApp.swift
@@ -82,7 +82,9 @@ struct MoonlightVisionApp: SwiftUI.App {
                      }
                 }
                 .windowStyle(.volumetric)
-                .defaultSize(width: 1.2, height: 1.2, depth: 1.2, in: .meters)
+                // The screen is scaled to fill the volume's width, so this is
+                // effectively the maximum screen size in volume mode.
+                .defaultSize(width: 2.0, height: 1.5, depth: 1.2, in: .meters)
 
                 // 2. Unbounded Immersive Space (New)
                 ImmersiveSpace(id: "realitykitImmersiveSpace", for: StreamConfiguration.self) { streamConfig in

--- a/Moonlight Vision/RealityKitStreamView.swift
+++ b/Moonlight Vision/RealityKitStreamView.swift
@@ -134,6 +134,12 @@ struct _RealityKitStreamView: View {
     @State private var volumeZLimits: ClosedRange<Float> = -0.5...0.5
     
     @State private var streamMan: StreamManager?
+    /// Non-nil when the stream renders through the system media pipeline
+    /// (AVSampleBufferVideoRenderer + VideoMaterial) instead of the Metal texture path.
+    @State private var systemRenderer: SystemVideoRenderer?
+    /// Created once per stream: an AVSampleBufferVideoRenderer feeds a single output,
+    /// so instantiating a second VideoMaterial for it steals the first one's video.
+    @State private var systemVideoMaterial: VideoMaterial?
     @State private var streamOpQueue = OperationQueue()
     @State private var controllerSupport: ControllerSupport?
     @StateObject var connectionCallbacks: ObservableConnectionManager = .init()
@@ -1781,6 +1787,22 @@ struct _RealityKitStreamView: View {
     }
     
     private func updateScreenMaterial() {
+        // System renderer: the mesh shows the system pipeline's video directly.
+        // Ambilight has no readable texture on this path, keep its planes hidden.
+        if let systemRenderer {
+            if systemVideoMaterial == nil {
+                systemVideoMaterial = VideoMaterial(videoRenderer: systemRenderer.sampleRenderer)
+            }
+            print("[StreamView] Binding VideoMaterial (screen.model=\(screen.model != nil ? "present" : "NIL"), parent=\(screen.parent != nil ? "attached" : "DETACHED"))")
+            if let systemVideoMaterial {
+                screen.model?.materials = [systemVideoMaterial]
+            }
+            for ambPlane in ambilightLayers {
+                ambPlane.components.set(OpacityComponent(opacity: 0.0))
+            }
+            return
+        }
+
         let mat = makeVideoUnlitMaterial(self.texture)
         if videoMode == .sideBySide3D {
             if var sMat = surfaceMaterial {
@@ -2402,11 +2424,43 @@ struct _RealityKitStreamView: View {
                 if !self.firstFrameReceived { LiRequestIdrFrame() }
             }
             
+            // System renderer path: decode + tone map through the system media pipeline
+            // (AVSampleBufferVideoRenderer → VideoMaterial) for true HDR/EDR output.
+            // Side-by-side 3D needs the Metal shader, so it forces the Metal path.
+            if self.viewModel.streamSettings.useSystemVideoRenderer && self.videoMode != .sideBySide3D {
+                self.connectionCallbacks.controllerSupport = self.controllerSupport
+                let renderer = SystemVideoRenderer(callbacks: self.connectionCallbacks) {
+                    guard !self.firstFrameReceived else { return }
+                    self.firstFrameReceived = true
+                    self.idrWatchdogTimer1?.invalidate(); self.idrWatchdogTimer1 = nil
+                    self.idrWatchdogTimer2?.invalidate(); self.idrWatchdogTimer2 = nil
+                    // Rebind after the first frame like the Metal path's rebind timer:
+                    // the screen entity may have been (re)built since the initial bind.
+                    self.updateScreenMaterial()
+                    self.controllerSupport?.connectionEstablished()
+                    self.startHideTimer()
+                }
+                self.systemRenderer = renderer
+                // Drop any material cached from a previous stream: it feeds the old
+                // renderer's sink and would leave the new stream black.
+                self.systemVideoMaterial = nil
+                self.updateScreenMaterial()
+                self.streamMan = StreamManager(
+                    config: self.streamConfig,
+                    rendererProvider: { renderer },
+                    connectionCallbacks: self.connectionCallbacks
+                )
+                if let streamMan = self.streamMan {
+                    self.streamOpQueue.addOperation(streamMan)
+                }
+                return
+            }
+
             self.recreateStreamTexture()
-            
+
             // Set controller support reference for rumble forwarding
             self.connectionCallbacks.controllerSupport = self.controllerSupport
-            
+
             // Capture texture locally for thread-safe background access
             let localTexture = self.texture
             
@@ -2709,7 +2763,9 @@ struct _RealityKitStreamView: View {
         postFirstFrameRebindTimer?.invalidate(); postFirstFrameRebindTimer = nil
         firstFrameReceived = false
         ambilightTexture = nil
-        
+        systemRenderer = nil
+        systemVideoMaterial = nil
+
         controllerSupport?.cleanup()
         controllerSupport = nil
         

--- a/Moonlight Vision/SettingsView.swift
+++ b/Moonlight Vision/SettingsView.swift
@@ -311,6 +311,20 @@ struct SettingsView: View {
                         Label(viewModel.localized("dim_passthrough"), systemImage: "moon.fill")
                     }
                     .onChange(of: settings.dimPassthrough) { _, _ in settings.save() }
+
+                    Toggle(isOn: $settings.useSystemVideoRenderer) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("System video renderer (true HDR)")
+                                Text("Full HDR brightness via the system media pipeline. Disables Ambilight, color grading and 3D modes.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: "sun.max.fill")
+                        }
+                    }
+                    .onChange(of: settings.useSystemVideoRenderer) { _, _ in settings.save() }
                 }
                 
                 Section(header: Label(viewModel.localized("input_audio_settings"), systemImage: "gamecontroller")) {

--- a/Moonlight Vision/SystemVideoRenderer.swift
+++ b/Moonlight Vision/SystemVideoRenderer.swift
@@ -1,0 +1,422 @@
+//
+//  SystemVideoRenderer.swift
+//  Moonlight Vision
+//
+//  A pull-mode video renderer that feeds compressed sample buffers straight into
+//  AVSampleBufferVideoRenderer, the system media pipeline's sample-buffer sink.
+//  Attached to a RealityKit VideoMaterial(videoRenderer:), this gives the curved
+//  RealityKit screen the exact same decode + tone-mapping path as AVPlayer/the
+//  UIKit AVSampleBufferDisplayLayer mode — including true HDR/EDR output, which
+//  the Metal-texture path (DrawableVideoDecoder) cannot get: RealityKit exposes
+//  no EDR API for custom textures and the compositor clamps them to ~1.2x SDR.
+//
+//  Trade-offs vs DrawableVideoDecoder: no Ambilight (no readable texture), no
+//  custom color grading shader, no side-by-side 3D. The stream view falls back
+//  to the Metal renderer when those features are requested.
+//
+//  Copyright © 2026 Moonlight Game Streaming Project. All rights reserved.
+//
+
+import AVFoundation
+import CoreMedia
+import Foundation
+import QuartzCore
+
+final class SystemVideoRenderer: NSObject, AnyVideoDecoderRenderer {
+
+    /// The sink handed to VideoMaterial(videoRenderer:).
+    let sampleRenderer = AVSampleBufferVideoRenderer()
+
+    private let synchronizer = AVSampleBufferRenderSynchronizer()
+    private let callbacks: ConnectionCallbacks
+    private let onFirstFrame: (() -> Void)?
+
+    private var videoFormat: Int32 = 0
+    private var frameRate: Int32 = 60
+    private var displayLink: CADisplayLink?
+
+    private var parameterSetBuffers: [[UInt8]] = []
+    private var formatDesc: CMVideoFormatDescription?
+    private var masteringDisplayColorVolume: Data?
+    private var contentLightLevelInfo: Data?
+    private var firstFrameEmitted = false
+    private var timelineAnchored = false
+    private var enqueuedCount = 0
+
+    init(callbacks: ConnectionCallbacks, onFirstFrame: (() -> Void)? = nil) {
+        self.callbacks = callbacks
+        self.onFirstFrame = onFirstFrame
+        super.init()
+        synchronizer.addRenderer(sampleRenderer)
+    }
+
+    // MARK: - AnyVideoDecoderRenderer
+
+    func setup(withVideoFormat videoFormat: Int32, width videoWidth: Int32, height videoHeight: Int32, frameRate: Int32) {
+        self.videoFormat = videoFormat
+        self.frameRate = frameRate
+        print("SystemVideoRenderer: setup format=\(String(format: "0x%04X", videoFormat)) \(videoWidth)x\(videoHeight)@\(frameRate)")
+    }
+
+    func start() {
+        print("SystemVideoRenderer: start()")
+
+        displayLink = CADisplayLink(target: self, selector: #selector(displayLinkCallback(_:)))
+        displayLink?.preferredFrameRateRange = CAFrameRateRange(
+            minimum: Float(frameRate),
+            maximum: Float(frameRate),
+            preferred: Float(frameRate)
+        )
+        displayLink?.add(to: .main, forMode: .default)
+    }
+
+    func stop() {
+        print("SystemVideoRenderer: stop()")
+        displayLink?.invalidate()
+        displayLink = nil
+        synchronizer.setRate(0, time: .zero)
+        sampleRenderer.flush()
+        formatDesc = nil
+        parameterSetBuffers.removeAll()
+        masteringDisplayColorVolume = nil
+        contentLightLevelInfo = nil
+        firstFrameEmitted = false
+        timelineAnchored = false
+        enqueuedCount = 0
+    }
+
+    func setHdrMode(_ enabled: Bool) {
+        let newMdcv = HDRParsingUtils.parseHDRDisplayMetadata(enabled)
+        let newClli = HDRParsingUtils.parseHDRLightMetadata(enabled)
+        let changed = (newMdcv != masteringDisplayColorVolume) || (newClli != contentLightLevelInfo)
+        masteringDisplayColorVolume = newMdcv
+        contentLightLevelInfo = newClli
+        if changed {
+            // Recreate the format description with the new metadata on the next IDR.
+            LiRequestIdrFrame()
+        }
+    }
+
+    // MARK: - Frame pump (pull-mode renderer, same pattern as DrawableVideoDecoder)
+
+    @objc private func displayLinkCallback(_: CADisplayLink) {
+        var handle: VIDEO_FRAME_HANDLE?
+        var du: PDECODE_UNIT?
+        while LiPollNextVideoFrame(&handle, &du) {
+            guard let handle = handle, let du = du else { continue }
+            LiCompleteVideoFrame(handle, DrSubmitDecodeUnit(du))
+        }
+    }
+
+    // MARK: - Decode buffer submission
+
+    @discardableResult
+    @objc(submitDecodeBuffer:length:bufferType:decodeUnit:)
+    func submitDecodeBuffer(
+        _ dataPtr: UnsafeMutablePointer<UInt8>!,
+        length: Int32,
+        bufferType: Int32,
+        decode decodeUnit: PDECODE_UNIT!
+    ) -> Int32 {
+        if decodeUnit.pointee.frameType == FRAME_TYPE_IDR {
+            if bufferType != BUFFER_TYPE_PICDATA {
+                if bufferType == BUFFER_TYPE_VPS || bufferType == BUFFER_TYPE_SPS || bufferType == BUFFER_TYPE_PPS {
+                    let startLen = (dataPtr[2] == 0x01) ? 3 : 4
+                    parameterSetBuffers.append([UInt8](Data(bytes: dataPtr + startLen, count: Int(length) - startLen)))
+                }
+                return DR_OK
+            }
+
+            guard let newDesc = recreateFormatDescriptionForIDR(dataPtr: dataPtr, length: length) else {
+                return DR_NEED_IDR
+            }
+            formatDesc = newDesc
+            AudioHelpers.fixAudioForSurroundForCurrentWindow()
+        }
+
+        guard let formatDesc = formatDesc else {
+            return DR_NEED_IDR
+        }
+
+        if sampleRenderer.status == .failed || sampleRenderer.requiresFlushToResumeDecoding {
+            print("SystemVideoRenderer: renderer failed (\(String(describing: sampleRenderer.error))), flushing")
+            sampleRenderer.flush()
+            free(dataPtr)
+            return DR_NEED_IDR
+        }
+
+        // createSampleBuffer takes ownership of dataPtr in every outcome:
+        // transferred to the CMBlockBuffer on success, freed internally on failure.
+        guard let sampleBuffer = createSampleBuffer(
+            dataPtr: dataPtr, length: Int(length), formatDesc: formatDesc, decodeUnit: decodeUnit
+        ) else {
+            return DR_NEED_IDR
+        }
+
+        // Bypass the synchronizer timeline: game streaming wants every frame on
+        // screen as soon as it is decoded. Use the CF API directly — a Swift
+        // conditional cast of the CFArray can fail silently.
+        if let attachmentsArray = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: true),
+           CFArrayGetCount(attachmentsArray) > 0 {
+            let dict = unsafeBitCast(CFArrayGetValueAtIndex(attachmentsArray, 0), to: CFMutableDictionary.self)
+            CFDictionarySetValue(
+                dict,
+                Unmanaged.passUnretained(kCMSampleAttachmentKey_DisplayImmediately).toOpaque(),
+                Unmanaged.passUnretained(kCFBooleanTrue).toOpaque()
+            )
+        }
+
+        // Anchor the synchronizer timebase to the stream's PTS domain on the first
+        // sample, so playback also works if DisplayImmediately is not honored.
+        if !timelineAnchored {
+            timelineAnchored = true
+            synchronizer.setRate(1.0, time: CMTimeMake(value: Int64(decodeUnit.pointee.presentationTimeMs), timescale: 1000))
+        }
+
+        sampleRenderer.enqueue(sampleBuffer)
+
+        enqueuedCount += 1
+        if enqueuedCount == 1 || enqueuedCount % 300 == 0 {
+            print("SystemVideoRenderer: enqueued=\(enqueuedCount) status=\(sampleRenderer.status.rawValue) error=\(String(describing: sampleRenderer.error)) rate=\(synchronizer.rate)")
+        }
+
+        if decodeUnit.pointee.frameType == FRAME_TYPE_IDR && !firstFrameEmitted {
+            firstFrameEmitted = true
+            callbacks.videoContentShown()
+            if let onFirstFrame = onFirstFrame {
+                DispatchQueue.main.async { onFirstFrame() }
+            }
+        }
+
+        return DR_OK
+    }
+
+    // MARK: - Format descriptions
+    // Mirrors the UIKit AVSampleBufferDisplayLayer path: parameter sets carry the
+    // colorimetry (VUI / sequence header), we only add HDR mastering metadata.
+
+    private func recreateFormatDescriptionForIDR(dataPtr: UnsafeMutablePointer<UInt8>, length: Int32) -> CMVideoFormatDescription? {
+        formatDesc = nil
+        defer { parameterSetBuffers.removeAll() }
+
+        if (videoFormat & VIDEO_FORMAT_MASK_H264) != 0 {
+            return createParameterSetFormatDescription(hevc: false)
+        } else if (videoFormat & VIDEO_FORMAT_MASK_H265) != 0 {
+            return createParameterSetFormatDescription(hevc: true)
+        } else if (videoFormat & VIDEO_FORMAT_MASK_AV1) != 0 {
+            let frameData = Data(bytes: dataPtr, count: Int(length))
+            return AV1FormatDescriptionBridge.formatDescription(
+                fromIDRFrame: frameData,
+                masteringDisplayColorVolume: masteringDisplayColorVolume,
+                contentLightLevelInfo: contentLightLevelInfo
+            )
+        }
+        return nil
+    }
+
+    private func createParameterSetFormatDescription(hevc: Bool) -> CMVideoFormatDescription? {
+        guard !parameterSetBuffers.isEmpty else { return nil }
+        var paramPtrs: [UnsafePointer<UInt8>] = []
+        var paramSizes: [Int] = []
+        for index in parameterSetBuffers.indices {
+            paramPtrs.append(UnsafePointer<UInt8>(parameterSetBuffers[index]))
+            paramSizes.append(parameterSetBuffers[index].count)
+        }
+
+        var desc: CMFormatDescription?
+        let status: OSStatus
+        if hevc {
+            let extensions = NSMutableDictionary()
+            if let mdcv = masteringDisplayColorVolume {
+                extensions[kCMFormatDescriptionExtension_MasteringDisplayColorVolume as NSString] = mdcv as NSData
+            }
+            if let clli = contentLightLevelInfo {
+                extensions[kCMFormatDescriptionExtension_ContentLightLevelInfo as NSString] = clli as NSData
+            }
+            status = CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+                allocator: kCFAllocatorDefault,
+                parameterSetCount: parameterSetBuffers.count,
+                parameterSetPointers: paramPtrs,
+                parameterSetSizes: paramSizes,
+                nalUnitHeaderLength: 4,
+                extensions: extensions as CFDictionary,
+                formatDescriptionOut: &desc
+            )
+        } else {
+            status = CMVideoFormatDescriptionCreateFromH264ParameterSets(
+                allocator: kCFAllocatorDefault,
+                parameterSetCount: parameterSetBuffers.count,
+                parameterSetPointers: paramPtrs,
+                parameterSetSizes: paramSizes,
+                nalUnitHeaderLength: 4,
+                formatDescriptionOut: &desc
+            )
+        }
+        if status != noErr {
+            print("SystemVideoRenderer: format description creation failed: \(status)")
+            return nil
+        }
+        return desc
+    }
+
+    // MARK: - Sample buffers (Annex B fixup identical to DrawableVideoDecoder)
+
+    private func createSampleBuffer(
+        dataPtr: UnsafeMutablePointer<UInt8>,
+        length: Int,
+        formatDesc: CMVideoFormatDescription,
+        decodeUnit: PDECODE_UNIT!
+    ) -> CMSampleBuffer? {
+        var frameBlockBuffer: CMBlockBuffer?
+
+        if (videoFormat & (VIDEO_FORMAT_MASK_H264 | VIDEO_FORMAT_MASK_H265)) != 0 {
+            let nals = UnsafeMutableBufferPointer<UInt8>(start: dataPtr, count: length)
+            frameBlockBuffer = annexBToLengthPrefixed(buffer: nals)
+        } else {
+            let status = CMBlockBufferCreateWithMemoryBlock(
+                allocator: nil,
+                memoryBlock: dataPtr,
+                blockLength: length,
+                blockAllocator: kCFAllocatorDefault,
+                customBlockSource: nil,
+                offsetToData: 0,
+                dataLength: length,
+                flags: 0,
+                blockBufferOut: &frameBlockBuffer
+            )
+            if status != kCMBlockBufferNoErr {
+                print("SystemVideoRenderer: CMBlockBufferCreateWithMemoryBlock failed: \(status)")
+                free(dataPtr)
+                return nil
+            }
+        }
+
+        guard frameBlockBuffer != nil else { return nil }
+
+        var sampleBuffer: CMSampleBuffer?
+        var sampleTiming = CMSampleTimingInfo(
+            duration: .invalid,
+            presentationTimeStamp: CMTimeMake(value: Int64(decodeUnit.pointee.presentationTimeMs), timescale: 1000),
+            decodeTimeStamp: .invalid
+        )
+        let status = CMSampleBufferCreateReady(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: frameBlockBuffer,
+            formatDescription: formatDesc,
+            sampleCount: 1,
+            sampleTimingEntryCount: 1,
+            sampleTimingArray: &sampleTiming,
+            sampleSizeEntryCount: 0,
+            sampleSizeArray: nil,
+            sampleBufferOut: &sampleBuffer
+        )
+        if status != noErr {
+            print("SystemVideoRenderer: CMSampleBufferCreateReady failed: \(status)")
+            return nil
+        }
+        return sampleBuffer
+    }
+
+    private struct NaluIndex {
+        var startOffset: Int
+        var payloadStartOffset: Int
+        var payloadSize: Int
+        var threeByteHeader: Bool
+    }
+
+    /// Rewrites Annex-B start codes into 4-byte big-endian length prefixes.
+    /// In-place when every start code is 4 bytes; otherwise falls back to a copy.
+    private func annexBToLengthPrefixed(buffer: UnsafeMutableBufferPointer<UInt8>) -> CMBlockBuffer? {
+        let (naluIndices, modifyInPlace) = findNaluIndices(bufferBounded: buffer)
+        guard !naluIndices.isEmpty else {
+            buffer.deallocate()
+            return nil
+        }
+
+        if modifyInPlace {
+            var offset = 0
+            let raw = UnsafeMutableRawBufferPointer(start: buffer.baseAddress, count: buffer.count)
+            guard let blockBuffer = try? CMBlockBuffer(buffer: raw, deallocator: { _, _ in buffer.deallocate() }, flags: .assureMemoryNow) else {
+                buffer.deallocate()
+                return nil
+            }
+            let pointer = buffer.baseAddress!
+            for index in naluIndices {
+                pointer.advanced(by: offset + 0).pointee = UInt8((index.payloadSize >> 24) & 0xFF)
+                pointer.advanced(by: offset + 1).pointee = UInt8((index.payloadSize >> 16) & 0xFF)
+                pointer.advanced(by: offset + 2).pointee = UInt8((index.payloadSize >> 8) & 0xFF)
+                pointer.advanced(by: offset + 3).pointee = UInt8(index.payloadSize & 0xFF)
+                offset += 4 + index.payloadSize
+            }
+            return blockBuffer
+        }
+
+        defer { buffer.deallocate() }
+        let blockLength = naluIndices.reduce(0) { $0 + 4 + $1.payloadSize }
+        guard let blockBuffer = try? CMBlockBuffer(length: blockLength, flags: .assureMemoryNow) else {
+            return nil
+        }
+        var contiguous: CMBlockBuffer! = blockBuffer
+        if !CMBlockBufferIsRangeContiguous(blockBuffer, atOffset: 0, length: 0) {
+            var created: CMBlockBuffer?
+            guard CMBlockBufferCreateContiguous(allocator: nil, sourceBuffer: blockBuffer, blockAllocator: nil, customBlockSource: nil, offsetToData: 0, dataLength: 0, flags: 0, blockBufferOut: &created) == noErr, created != nil else {
+                return nil
+            }
+            contiguous = created
+        }
+        var totalLength = 0
+        var rawPtr: UnsafeMutablePointer<Int8>!
+        guard CMBlockBufferGetDataPointer(contiguous, atOffset: 0, lengthAtOffsetOut: nil, totalLengthOut: &totalLength, dataPointerOut: &rawPtr) == noErr else {
+            return nil
+        }
+        let dst = UnsafeMutableRawPointer(rawPtr).assumingMemoryBound(to: UInt8.self)
+        let src = buffer.baseAddress!
+        var offset = 0
+        for index in naluIndices {
+            dst.advanced(by: offset + 0).pointee = UInt8((index.payloadSize >> 24) & 0xFF)
+            dst.advanced(by: offset + 1).pointee = UInt8((index.payloadSize >> 16) & 0xFF)
+            dst.advanced(by: offset + 2).pointee = UInt8((index.payloadSize >> 8) & 0xFF)
+            dst.advanced(by: offset + 3).pointee = UInt8(index.payloadSize & 0xFF)
+            offset += 4
+            dst.advanced(by: offset).update(from: src.advanced(by: index.payloadStartOffset), count: index.payloadSize)
+            offset += index.payloadSize
+        }
+        return contiguous
+    }
+
+    private func findNaluIndices(bufferBounded: UnsafeMutableBufferPointer<UInt8>) -> ([NaluIndex], Bool) {
+        var eligibleForModifyInPlace = true
+        guard bufferBounded.count >= 3 else { return ([], false) }
+
+        var sequences = [NaluIndex]()
+        let end = bufferBounded.count - 3
+        var i = 0
+        let buffer = Data(bytesNoCopy: bufferBounded.baseAddress!, count: bufferBounded.count, deallocator: .none)
+        while i < end {
+            if buffer[i + 2] > 1 {
+                i += 3
+            } else if buffer[i + 2] == 1 {
+                if buffer[i + 1] == 0 && buffer[i] == 0 {
+                    var index = NaluIndex(startOffset: i, payloadStartOffset: i + 3, payloadSize: 0, threeByteHeader: true)
+                    if index.startOffset > 0 && buffer[index.startOffset - 1] == 0 {
+                        index.startOffset -= 1
+                        index.threeByteHeader = false
+                    } else {
+                        eligibleForModifyInPlace = false
+                    }
+                    if !sequences.isEmpty {
+                        sequences[sequences.count - 1].payloadSize = index.startOffset - sequences.last!.payloadStartOffset
+                    }
+                    sequences.append(index)
+                }
+                i += 3
+            } else {
+                i += 1
+            }
+        }
+        if !sequences.isEmpty {
+            sequences[sequences.count - 1].payloadSize = bufferBounded.count - sequences.last!.payloadStartOffset
+        }
+        return (sequences, eligibleForModifyInPlace)
+    }
+}

--- a/Moonlight.xcodeproj/project.pbxproj
+++ b/Moonlight.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		B1EDB13D2D4D95BF00EB1839 /* StreamConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EDB13B2D4D95BF00EB1839 /* StreamConfiguration.swift */; };
 		B1EDB13E2D4D95BF00EB1839 /* StreamConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EDB13B2D4D95BF00EB1839 /* StreamConfiguration.swift */; };
 		C2769339D74B457E85143624 /* AV1Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5924693D218D4AB18BB554DD /* AV1Parser.swift */; };
+		B2936465EFD347E4BA5FFD28 /* SystemVideoRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CA15DC719441F8D881F87 /* SystemVideoRenderer.swift */; };
 		DC1F5A07206436B20037755F /* ConnectionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1F5A06206436B20037755F /* ConnectionHelper.m */; };
 		E77582CD2D53F3EB00948545 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = E77582CC2D53F3E500948545 /* Shaders.metal */; };
 		E77582CF2D54020700948545 /* CVMetalHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77582CE2D54020300948545 /* CVMetalHelpers.swift */; };
@@ -346,6 +347,7 @@
 		3EBD94A62F9D41190016D2AF /* SharePlayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePlayManager.swift; sourceTree = "<group>"; };
 		566E9D2B2770B23A00EF7BFE /* Moonlight v1.7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Moonlight v1.7.xcdatamodel"; sourceTree = "<group>"; };
 		5924693D218D4AB18BB554DD /* AV1Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AV1Parser.swift; sourceTree = "<group>"; };
+		D08CA15DC719441F8D881F87 /* SystemVideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemVideoRenderer.swift; sourceTree = "<group>"; };
 		6581B5F02D5434100022400F /* VideoTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTypes.swift; sourceTree = "<group>"; };
 		659789EB2D55A93A00B88B25 /* SBSMaterial.usda */ = {isa = PBXFileReference; lastKnownFileType = text; path = SBSMaterial.usda; sourceTree = "<group>"; };
 		693B3A9A218638CD00982F7B /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -792,6 +794,7 @@
 				3E8100A52ED566510011CB9F /* AV1Helper.h */,
 				3E8100A62ED5666B0011CB9F /* AV1Helper.m */,
 				5924693D218D4AB18BB554DD /* AV1Parser.swift */,
+				D08CA15DC719441F8D881F87 /* SystemVideoRenderer.swift */,
 				F77B58B12B5EFC9000482BD5 /* ComputerView.swift */,
 				3E4F94682DC2E2D6006CF0C1 /* ComputerViewWrapper.swift */,
 				04F5ECAE2EE37A7F009FF87D /* ControlPanel */,
@@ -1455,6 +1458,7 @@
 				F7A119172B5DDF73001E8686 /* WakeOnLanManager.m in Sources */,
 				B1EDB1352D4D95A700EB1839 /* StreamControls.swift in Sources */,
 				C2769339D74B457E85143624 /* AV1Parser.swift in Sources */,
+				B2936465EFD347E4BA5FFD28 /* SystemVideoRenderer.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* StreamViewStubs.swift in Sources */,
 				B1EDB1362D4D95A700EB1839 /* DrawableVideoDecoder.swift in Sources */,
 				3E86FC1D2D4FFDF20016BB8E /* UpdatesView.swift in Sources */,


### PR DESCRIPTION
## Problem

RealityKit exposes no EDR API for custom textures: the Metal path (`DrawableVideoDecoder` writing `rgba16Float` into an `UnlitMaterial`) is clamped by the compositor to roughly 1.2x SDR (~250 nits measured with the Windows HDR calibration app, on visionOS 27 beta), regardless of passthrough dimming. Meanwhile the system video pipeline - AVPlayer, `AVSampleBufferDisplayLayer`, i.e. this app's UIKit mode - reaches the panel's full HDR range. So users had to choose: curved screen or real HDR.

## Approach

Since visionOS 2.0, `VideoMaterial` accepts an `AVSampleBufferVideoRenderer` - the system pipeline's sample-buffer sink. `SystemVideoRenderer` is a pull-mode `AnyVideoDecoderRenderer` that enqueues *compressed* samples (H.264/HEVC from parameter sets, AV1 via the FFmpeg-free Swift parser from #21) tagged `kCMSampleAttachmentKey_DisplayImmediately`, bound to the existing curved mesh with `VideoMaterial(videoRenderer:)`. The system decodes and tone-maps with true EDR.

## Measured result

Windows HDR calibration on the RealityKit curved screen: ~250 nits before, **~2600 nits** after - same range as UIKit mode. AV1 Main10 5120x2160 @ 120 fps ran extended sessions with zero queue overflows (AVP M5, visionOS 27 beta 24M5326g, Apollo v0.4.6, 200 Mbps).

## Trade-offs (hence a toggle, default ON)

Decoded pixels never enter app memory on this path, so no Ambilight and no custom color grading; side-by-side 3D forces the Metal path automatically. The "System video renderer (true HDR)" toggle in the RealityKit settings restores the previous behavior.

## Implementation notes

- One `AVSampleBufferVideoRenderer` feeds exactly one `VideoMaterial`: re-instantiating the material steals the previous one's output (one frame then black), so the material is created once per stream and rebound, invalidated on stream restart.
- The synchronizer timebase is anchored to the stream's first PTS as a fallback in case `DisplayImmediately` is not honored.
- `DisplayImmediately` is set through the CF API directly; a Swift conditional cast of the attachments array can fail silently.

Second commit (droppable if you disagree): default volume enlarged to 2.0 x 1.5 x 1.2 m - the screen is scaled to fill the volume width, so the declared size is effectively the maximum screen size in volume mode.

Stacked on #21 (contains its commits); will rebase once it lands.

🤖 Coded with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)